### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.slf4j)  // Apache-2.0
     implementation(libs.slf4j.api) // MIT
 
-    implementation(libs.sslcontext.kickstart.pem) // Apache-2.0
+    implementation(libs.ayza.pem) // Apache-2.0
     implementation(libs.bctls.jdk18) // Bouncy Castle License (~MIT)
 
     testImplementation(kotlin("test"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
             library("ktor-network-jvm", "io.ktor:ktor-network-jvm:3.2.3")
             library("kotlinx-coroutines-slf4j", "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.10.2")
             library("slf4j-api", "org.slf4j:slf4j-api:2.0.17")
-            library("sslcontext-kickstart-pem", "io.github.hakky54:sslcontext-kickstart-for-pem:9.1.0")
+            library("ayza-pem", "io.github.hakky54:ayza-for-pem:10.0.0")
             library("bctls-jdk18", "org.bouncycastle:bctls-jdk18on:1.81")
 
             library("logback-classic", "ch.qos.logback:logback-classic:1.5.18")


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience