### PR TITLE
feat: add CAN bus support with ISO-TP and multi-transport DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ bin
 *.key
 *.der
 *.srl
+.junie
+.claude

--- a/README.md
+++ b/README.md
@@ -85,6 +85,110 @@ The simulation will now respond to UDP and TCP-Requests on their configured port
 and handle incoming messages/requests.
 
 
+### CAN / ISO-TP support
+
+Besides DoIP, ECUs can also be simulated on a CAN bus, speaking UDS over ISO-TP
+(ISO 15765-2). The ISO-TP layer (segmentation, reassembly and flow control, including
+CAN FD escape encodings) is implemented in pure Kotlin on top of a raw CAN frame
+transport, of which there are two:
+
+| Transport | Use case | Platform |
+|---|---|---|
+| `socketCan("vcan0")` | SocketCAN network devices: real hardware, `vcan`, `vxcan` pairs (e.g. into a container) | Linux only, requires the optional `tel.schich:javacan-core` dependency |
+| `socketcand(host, port, bus)` | CAN over TCP via a [socketcand](https://github.com/linux-can/socketcand) daemon (rawmode); also usable from Windows/macOS or containers without `NET_ADMIN` | any |
+
+ECUs on a CAN bus reuse the same request-matcher DSL as DoIP ECUs, but are addressed
+by a physical request/response CAN id pair (plus an optional functional id):
+
+```kotlin
+network {
+    canBus("BUS1") {
+        transport = socketCan("vcan0")
+        // or: transport = socketcand(host = "172.22.1.5", bus = "can0")
+        functionalRequestId = 0x7DF
+        // fd = true; txDlc = 64    // CAN FD (SocketCAN only)
+
+        ecu("ECU1") {
+            requestId = 0x712
+            responseId = 0x7A2
+            isoTp { blockSize = 8; stMin = 0 }   // optional ISO-TP tuning
+
+            request("22 F1 86") { respond("62 F1 86 01") }
+            request("3E 00") { ack() }
+        }
+    }
+}
+start()
+```
+
+#### Dual-homed ECUs (DoIP + CAN)
+
+An ECU that should be reachable via DoIP *and* CAN at the same time can be defined
+once inside a `multiTransport` block. It is then a **single ECU instance**: stored
+properties, timers, interceptors and the busy-state are shared across both
+transports - like a real ECU with two network interfaces.
+
+```kotlin
+network {
+    multiTransport(
+        gateway("GW") { logicalAddress = 0x1010 },
+        canBus("BUS1") { transport = socketCan("vcan0") },
+    ) {
+        ecu("ECU1") {
+            logicalAddress = 0x1011               // DoIP addressing
+            requestId = 0x712; responseId = 0x7A2 // CAN addressing
+            request("22 F1 86") { respond("62 F1 86 01") }
+        }
+    }
+}
+```
+
+`gateway`, `doipEntity` and `canBus` return their configuration objects, so they can
+also be defined first and passed by reference. A `multiTransport` block accepts any
+number of CAN buses but at most one DoIP entity.
+
+If two *independent* ECUs (with separate state) should merely share their request
+definitions, use a plain lambda instead:
+
+```kotlin
+val ecu1Requests: RequestsData.() -> Unit = {
+    request("22 F1 86") { respond("62 F1 86 01 02 03") }
+}
+network {
+    gateway("GW") { ecu("ECU1") { logicalAddress = 0x1011; ecu1Requests() } }
+    canBus("BUS1") { ecu("ECU1") { requestId = 0x712; responseId = 0x7A2; ecu1Requests() } }
+}
+```
+
+For SocketCAN, add the optional dependency (and the natives for your architecture)
+to your own project:
+
+```kotlin
+implementation("tel.schich:javacan-core:3.5.2")
+implementation("tel.schich:javacan-core:3.5.2:x86_64")   // natives; or javacan-core-arch-detect
+```
+
+A virtual CAN interface for local testing is set up with:
+
+```bash
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+# for CAN FD: sudo ip link set vcan0 mtu 72 (before setting it up)
+
+# a vxcan tunnel pair (e.g. one end moved into a container/network namespace):
+sudo ip link add vxcan0 type vxcan peer name vxcan1
+```
+
+The simulation can be cross-checked with [can-utils](https://github.com/linux-can/can-utils),
+e.g. `candump vcan0` or `isotpsend -s 712 -d 7a2 vcan0`. Linux-only integration tests are
+excluded by default and can be enabled with `gradlew test -PcanIntegrationTests`.
+
+Limitations: CAN FD is not available via socketcand (the upstream protocol has no FD
+frame message), `hardResetEntityFor` is a DoIP-entity concept and is ignored on CAN, and
+sub-millisecond STmin values (0xF1-0xF9) are rounded up to 1 ms.
+
+
 ### Acknowledgements
 In an earlier version this library utilized the [doip-simulation](https://github.com/doip/doip-simulation) project 
 for the DoIP-stack. The stack has since been replaced by a custom kotlin implementation, 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,13 @@ dependencies {
     implementation(libs.ayza.pem) // Apache-2.0
     implementation(libs.bctls.jdk18) // Bouncy Castle License (~MIT)
 
+    // optional - only required for SocketCAN transports; users add it (plus the
+    // architecture classifier jar with the natives) to their own dependencies
+    compileOnly(libs.javacan.core) // MIT
+
     testImplementation(kotlin("test"))
+    testImplementation(libs.javacan.core)
+    testImplementation(libs.kotlinx.coroutines.test)
     testRuntimeOnly(libs.logback.classic) // EPL-1.0
 
     // version 6.x requires jdk 17
@@ -42,7 +48,12 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        // tests requiring a linux CAN stack (vcan) are opt-in via -PcanIntegrationTests
+        if (!project.hasProperty("canIntegrationTests")) {
+            excludeTags("linux-can")
+        }
+    }
 }
 
 java {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,11 +11,14 @@ dependencyResolutionManagement {
 
             library("ktor-network-jvm", "io.ktor:ktor-network-jvm:3.4.0")
             library("kotlinx-coroutines-slf4j", "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.10.2")
+            // optional dependency for SocketCAN support (linux only)
+            library("javacan-core", "tel.schich:javacan-core:3.5.2")
             library("slf4j-api", "org.slf4j:slf4j-api:2.0.17")
             library("ayza-pem", "io.github.hakky54:ayza-for-pem:10.0.3")
             library("bctls-jdk18", "org.bouncycastle:bctls-jdk18on:1.83")
 
             library("logback-classic", "ch.qos.logback:logback-classic:1.5.32")
+            library("kotlinx-coroutines-test", "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
             library("junit-jupiter", "org.junit.jupiter:junit-jupiter:6.0.3")
             library("mockito-kotlin", "org.mockito.kotlin:mockito-kotlin:6.2.3")
             library("assertk-jvm", "com.willowtreeapps.assertk:assertk-jvm:0.28.1")

--- a/src/main/kotlin/CanBusBinding.kt
+++ b/src/main/kotlin/CanBusBinding.kt
@@ -1,0 +1,202 @@
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.slf4j.MDCContext
+import library.DoipEntityHardResetException
+import library.UdsMessage
+import library.can.CanFrame
+import library.can.CanTransport
+import library.can.CanUdsMessage
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpOptions
+import library.toHexString
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+
+/**
+ * Runtime instance for a [CanBusData]: owns the [CanTransport], one [SimEcu] and
+ * [IsoTpEndpoint] per defined ECU, and dispatches reassembled UDS requests
+ */
+public open class CanBusBinding(
+    public val data: CanBusData,
+    /**
+     * ECU instances shared with other transports (multiTransport), keyed by the
+     * identity of their [library.EcuConfig]-source [EcuData]; an ECU whose data is
+     * already in this map is adopted instead of instantiated a second time
+     */
+    private val sharedEcuInstances: MutableMap<EcuData, SimEcu> = mutableMapOf(),
+) {
+    private val logger = LoggerFactory.getLogger(CanBusBinding::class.java)
+
+    public val name: String
+        get() = data.name
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var transport: CanTransport? = null
+    private val endpoints: MutableList<IsoTpEndpoint> = mutableListOf()
+
+    private val _ecus: MutableList<SimEcu> = mutableListOf()
+    private val ownedEcus: MutableList<SimEcu> = mutableListOf()
+
+    public val ecus: List<SimEcu>
+        get() = _ecus
+
+    /**
+     * Creates the simulated ECUs (doesn't open the transport yet, see [startNetworking])
+     */
+    public fun start() {
+        _ecus.clear()
+        ownedEcus.clear()
+        data.ecus.forEach { ecuData ->
+            val existing = sharedEcuInstances[ecuData]
+            if (existing != null) {
+                // dual-homed ECU - the instance (and its state) is shared with another transport
+                _ecus.add(existing)
+            } else {
+                val simEcu = SimEcu(ecuData)
+                sharedEcuInstances[ecuData] = simEcu
+                ownedEcus.add(simEcu)
+                _ecus.add(simEcu)
+                simEcu.simStarted()
+            }
+        }
+    }
+
+    /**
+     * Validates the configuration, opens the transport and attaches the ISO-TP endpoints
+     */
+    public fun startNetworking() {
+        val transportConfig = data.transport
+            ?: throw IllegalArgumentException("No transport configured for CAN bus '$name'")
+        validate()
+
+        val transport = createTransport(transportConfig)
+        if (data.fd && !transport.supportsFd) {
+            transport.close()
+            throw IllegalArgumentException("CAN bus '$name' is configured with fd=true, but transport '${transport.name}' doesn't support CAN FD")
+        }
+        this.transport = transport
+
+        // attach the endpoints before connecting, so no frame received right after
+        // connecting can be lost
+        data.ecus.zip(_ecus).forEach { (ecuData, simEcu) ->
+            val options = effectiveIsoTpOptions(ecuData)
+            val functionalRxId = if (ecuData.useFunctionalAddressing) data.functionalRequestId else null
+            lateinit var endpoint: IsoTpEndpoint
+            endpoint = IsoTpEndpoint(
+                transport = transport,
+                physicalRxId = ecuData.requestId,
+                functionalRxId = functionalRxId,
+                txId = ecuData.responseId,
+                options = options,
+            ) { payload, functional ->
+                dispatchRequest(simEcu, ecuData, endpoint, payload, functional)
+            }
+            endpoint.start(scope)
+            endpoints.add(endpoint)
+            logger.info("ECU '${simEcu.name}' listening on 0x${ecuData.requestId.toString(16)} (responding on 0x${ecuData.responseId.toString(16)})")
+        }
+
+        runBlocking {
+            transport.start(scope)
+        }
+        logger.info("CAN bus '$name' connected via ${transport.name}")
+    }
+
+    public fun stop() {
+        endpoints.forEach { it.stop() }
+        endpoints.clear()
+        transport?.close()
+        transport = null
+        scope.cancel()
+    }
+
+    public open fun reset() {
+        // adopted (shared) ECUs are reset by their owning transport
+        ownedEcus.forEach { it.reset() }
+    }
+
+    public fun findEcuByName(ecuName: String, ignoreCase: Boolean = true): SimEcu? =
+        _ecus.firstOrNull { ecuName.equals(it.name, ignoreCase) }
+
+    private fun dispatchRequest(
+        simEcu: SimEcu,
+        ecuData: CanEcuData,
+        endpoint: IsoTpEndpoint,
+        payload: ByteArray,
+        functional: Boolean,
+    ) {
+        val request = CanUdsMessage(
+            targetAddressType = if (functional) UdsMessage.FUNCTIONAL else UdsMessage.PHYSICAL,
+            message = payload,
+            output = endpoint.outputChannel,
+            requestCanId = if (functional) data.functionalRequestId!! else ecuData.requestId,
+            responseCanId = ecuData.responseId,
+        )
+        MDC.put("ecu", simEcu.name)
+        scope.launch(MDCContext()) {
+            try {
+                simEcu.onIncomingUdsMessage(request)
+            } catch (e: DoipEntityHardResetException) {
+                logger.warn("hardResetEntityFor isn't supported on CAN (ECU '${simEcu.name}')")
+            } catch (e: Exception) {
+                logger.error(
+                    "Error while handling request '${payload.toHexString(limit = 10, limitExceededByteCount = true)}' for ECU '${simEcu.name}'",
+                    e
+                )
+            }
+        }
+    }
+
+    private fun effectiveIsoTpOptions(ecuData: CanEcuData): IsoTpOptions {
+        val options = IsoTpOptions(
+            fd = data.fd,
+            txDlc = data.txDlc,
+            paddingByte = data.padding,
+        )
+        data.isoTpHandler?.invoke(options)
+        ecuData.isoTpHandler?.invoke(options)
+        return options
+    }
+
+    private fun validate() {
+        data.ecus.forEach {
+            require(it.requestId in 0..CanFrame.MAX_STANDARD_ID) {
+                "ECU '${it.name}' on CAN bus '$name' has no valid requestId (11-bit CAN id required)"
+            }
+            require(it.responseId in 0..CanFrame.MAX_STANDARD_ID) {
+                "ECU '${it.name}' on CAN bus '$name' has no valid responseId (11-bit CAN id required)"
+            }
+        }
+        val duplicateRxIds = data.ecus.groupBy { it.requestId }.filterValues { it.size > 1 }
+        require(duplicateRxIds.isEmpty()) {
+            "CAN bus '$name' has multiple ECUs with the same requestId: ${duplicateRxIds.keys.map { "0x${it.toString(16)}" }}"
+        }
+        data.functionalRequestId?.let { functionalId ->
+            require(functionalId in 0..CanFrame.MAX_STANDARD_ID) {
+                "CAN bus '$name' has an invalid functionalRequestId (11-bit CAN id required)"
+            }
+            require(data.ecus.none { it.requestId == functionalId }) {
+                "CAN bus '$name': functionalRequestId 0x${functionalId.toString(16)} collides with an ECU requestId"
+            }
+        }
+        require(data.txDlc == 8 || (data.fd && library.can.CanDlc.isValidLength(data.txDlc) && data.txDlc > 8)) {
+            "CAN bus '$name' has an invalid txDlc ${data.txDlc} (8 for classic CAN; 12, 16, 20, 24, 32, 48 or 64 with fd=true)"
+        }
+    }
+
+    protected open fun createTransport(config: CanTransportConfig): CanTransport =
+        when (config) {
+            is LoopbackConfig -> config.transport
+            is SocketcandConfig -> library.can.socketcand.SocketcandTransport(
+                host = config.host,
+                port = config.port,
+                busName = config.busName,
+                reconnect = config.reconnect,
+            )
+            is SocketCanConfig -> library.can.socketcan.SocketCanTransport(config.interfaceName)
+        }
+}

--- a/src/main/kotlin/CanBusBinding.kt
+++ b/src/main/kotlin/CanBusBinding.kt
@@ -14,7 +14,6 @@ import library.can.isotp.IsoTpEndpoint
 import library.can.isotp.IsoTpOptions
 import library.toHexString
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 
 /**
  * Runtime instance for a [CanBusData]: owns the [CanTransport], one [SimEcu] and
@@ -136,8 +135,7 @@ public open class CanBusBinding(
             requestCanId = if (functional) data.functionalRequestId!! else ecuData.requestId,
             responseCanId = ecuData.responseId,
         )
-        MDC.put("ecu", simEcu.name)
-        scope.launch(MDCContext()) {
+        scope.launch(MDCContext(mapOf("ecu" to simEcu.name))) {
             try {
                 simEcu.onIncomingUdsMessage(request)
             } catch (e: DoipEntityHardResetException) {
@@ -197,6 +195,6 @@ public open class CanBusBinding(
                 busName = config.busName,
                 reconnect = config.reconnect,
             )
-            is SocketCanConfig -> library.can.socketcan.SocketCanTransport(config.interfaceName)
+            is SocketCanConfig -> library.can.socketcan.SocketCanTransport(config.interfaceName, enableFd = data.fd)
         }
 }

--- a/src/main/kotlin/NetworkManager.kt
+++ b/src/main/kotlin/NetworkManager.kt
@@ -14,6 +14,7 @@ import java.net.NetworkInterface
 public open class NetworkManager(
     public val config: NetworkingData,
     public val doipEntities: List<DoipEntity<*>>,
+    public val canBusBindings: List<CanBusBinding> = emptyList(),
 ) {
     private val log = LoggerFactory.getLogger(NetworkManager::class.java)
     private val udpNetworkBindings: MutableList<UdpNetworkBinding> = mutableListOf()
@@ -101,6 +102,15 @@ public open class NetworkManager(
     }
 
     public fun start() {
+        // CAN buses are independent of the ip-based startup map
+        canBusBindings.forEach {
+            it.startNetworking()
+        }
+
+        if (doipEntities.isEmpty()) {
+            return
+        }
+
         val map = buildStartupMap()
 
         // UDP

--- a/src/main/kotlin/SimCanDsl.kt
+++ b/src/main/kotlin/SimCanDsl.kt
@@ -1,0 +1,145 @@
+import library.can.LoopbackCanTransport
+import library.can.isotp.IsoTpOptions
+
+public typealias CanEcuDataHandler = CanEcuData.() -> Unit
+public typealias CanBusDataHandler = CanBusData.() -> Unit
+
+/**
+ * Configuration of the raw CAN frame transport used by a [CanBusData]
+ */
+public sealed class CanTransportConfig
+
+public class SocketCanConfig(
+    public val interfaceName: String,
+) : CanTransportConfig()
+
+public class SocketcandConfig(
+    public val host: String,
+    public val port: Int,
+    public val busName: String,
+    public val reconnect: Boolean,
+) : CanTransportConfig()
+
+public class LoopbackConfig(
+    public val transport: LoopbackCanTransport,
+) : CanTransportConfig()
+
+/**
+ * Connect to a SocketCAN network device (e.g. can0, vcan0, vxcan0) by interface name.
+ *
+ * Linux only; requires the optional `tel.schich:javacan-core` dependency (plus its
+ * architecture classifier jar) on the classpath.
+ */
+public fun socketCan(interfaceName: String): CanTransportConfig {
+    try {
+        Class.forName("tel.schich.javacan.CanChannels")
+    } catch (e: ClassNotFoundException) {
+        throw IllegalStateException(
+            "SocketCAN support requires the optional dependency 'tel.schich:javacan-core' " +
+                "(and its architecture classifier jar, e.g. classifier 'x86_64') on the classpath",
+            e
+        )
+    }
+    return SocketCanConfig(interfaceName)
+}
+
+/**
+ * Connect to a CAN bus through a socketcand daemon (rawmode) over TCP
+ */
+public fun socketcand(host: String, port: Int = 29536, bus: String, reconnect: Boolean = true): CanTransportConfig =
+    SocketcandConfig(host = host, port = port, busName = bus, reconnect = reconnect)
+
+/**
+ * In-memory CAN bus, mainly useful for tests - a tester can be attached to the
+ * same [LoopbackCanTransport] instance
+ */
+public fun loopback(transport: LoopbackCanTransport = LoopbackCanTransport()): CanTransportConfig =
+    LoopbackConfig(transport)
+
+/**
+ * Defines a CAN bus with ECUs reachable via UDS over ISO-TP (ISO 15765-2)
+ */
+public class CanBusData(public val name: String) : MultiTransportTarget {
+    /**
+     * The CAN frame transport for this bus (see [socketCan], [socketcand], [loopback])
+     */
+    public var transport: CanTransportConfig? = null
+
+    /**
+     * Use CAN FD framing (payloads up to 64 bytes per frame); requires a transport
+     * that supports FD frames (SocketCAN, not socketcand)
+     */
+    public var fd: Boolean = false
+
+    /**
+     * Maximum payload length of transmitted frames: 8 for classic CAN, up to 64 with [fd]
+     */
+    public var txDlc: Int = 8
+
+    /**
+     * Byte used to pad transmitted frames to their full length (null = no padding)
+     */
+    public var padding: Byte? = 0xCC.toByte()
+
+    /**
+     * CAN id for functional (broadcast) requests, e.g. 0x7DF (null = no functional addressing)
+     */
+    public var functionalRequestId: Int? = null
+
+    internal var isoTpHandler: (IsoTpOptions.() -> Unit)? = null
+
+    internal val _ecus: MutableList<CanEcuData> = mutableListOf()
+
+    public val ecus: List<CanEcuData>
+        get() = _ecus
+
+    /**
+     * Bus-wide defaults for ISO-TP parameters (overridable per ECU)
+     */
+    public fun isoTp(receiver: IsoTpOptions.() -> Unit) {
+        isoTpHandler = receiver
+    }
+
+    /**
+     * Defines an ECU on this CAN bus and its request/response behaviour
+     */
+    public fun ecu(name: String, receiver: CanEcuDataHandler) {
+        val ecuData = CanEcuData(name)
+        receiver.invoke(ecuData)
+        _ecus.add(ecuData)
+    }
+
+    internal fun addEcu(ecuData: CanEcuData) {
+        _ecus.add(ecuData)
+    }
+}
+
+/**
+ * The data associated with an ECU on a CAN bus; reuses the request-matcher DSL
+ * of [EcuData] but is addressed by CAN ids instead of DoIP logical addresses
+ */
+public class CanEcuData(name: String) : EcuData(name) {
+    /**
+     * CAN id the ECU receives physical requests on (e.g. 0x712)
+     */
+    public var requestId: Int = -1
+
+    /**
+     * CAN id the ECU sends its responses on (e.g. 0x7A2)
+     */
+    public var responseId: Int = -1
+
+    /**
+     * Whether this ECU also listens to the bus' functional request id
+     */
+    public var useFunctionalAddressing: Boolean = true
+
+    internal var isoTpHandler: (IsoTpOptions.() -> Unit)? = null
+
+    /**
+     * Per-ECU overrides for ISO-TP parameters (e.g. blockSize, stMin)
+     */
+    public fun isoTp(receiver: IsoTpOptions.() -> Unit) {
+        isoTpHandler = receiver
+    }
+}

--- a/src/main/kotlin/SimDoipEntity.kt
+++ b/src/main/kotlin/SimDoipEntity.kt
@@ -5,7 +5,7 @@ import library.*
 import org.slf4j.MDC
 
 @Suppress("unused")
-public open class DoipEntityData(name: String, public val nodeType: DoipNodeType = DoipNodeType.GATEWAY) : EcuData(name) {
+public open class DoipEntityData(name: String, public val nodeType: DoipNodeType = DoipNodeType.GATEWAY) : EcuData(name), MultiTransportTarget {
     /**
      * Vehicle identifier, 17 chars, will be filled with '0', or if left null, set to 0xFF
      */
@@ -39,6 +39,10 @@ public open class DoipEntityData(name: String, public val nodeType: DoipNodeType
         receiver.invoke(ecuData)
         _ecus.add(ecuData)
     }
+
+    internal fun addEcu(ecuData: EcuData) {
+        _ecus.add(ecuData)
+    }
 }
 
 private fun DoipEntityData.toDoipEntityConfig(): DoipEntityConfig {
@@ -69,7 +73,14 @@ private fun DoipEntityData.toDoipEntityConfig(): DoipEntityConfig {
 }
 
 @Suppress("MemberVisibilityCanBePrivate")
-public open class SimDoipEntity(private val data: DoipEntityData) : DoipEntity<SimEcu>(data.toDoipEntityConfig()) {
+public open class SimDoipEntity(
+    private val data: DoipEntityData,
+    /**
+     * ECU instances shared with other transports (e.g. a CAN bus via multiTransport),
+     * keyed by the identity of their [EcuData]
+     */
+    private val sharedEcuInstances: MutableMap<EcuData, SimEcu> = mutableMapOf(),
+) : DoipEntity<SimEcu>(data.toDoipEntityConfig()) {
     public val requests: RequestList
         get() = data.requests
 
@@ -92,7 +103,9 @@ public open class SimDoipEntity(private val data: DoipEntityData) : DoipEntity<S
         // Match the other ecus by name, and create an SimDslEcu for them, since StandardEcu can't handle our
         // requirements for handling requests
         val ecuData = data.ecus.first { it.name == config.name }
-        return SimEcu(ecuData)
+        // register the instance, so transports sharing the same EcuData (multiTransport)
+        // adopt it instead of creating a second one
+        return sharedEcuInstances.getOrPut(ecuData) { SimEcu(ecuData) }
     }
 
     public override fun reset(recursiveEcus: Boolean) {

--- a/src/main/kotlin/SimDsl.kt
+++ b/src/main/kotlin/SimDsl.kt
@@ -569,7 +569,7 @@ public fun reset() {
 public fun start() {
     networkInstances.addAll(networks.map { SimDoipNetworking(it) })
 
-    val networkManager = networkInstances.map { NetworkManager(it.data, it.doipEntities) }
+    val networkManager = networkInstances.map { NetworkManager(it.data, it.doipEntities, it.canBusBindings) }
 
     networkManager.forEach {
         it.start()

--- a/src/main/kotlin/SimMultiTransportDsl.kt
+++ b/src/main/kotlin/SimMultiTransportDsl.kt
@@ -1,0 +1,68 @@
+public typealias MultiTransportDataHandler = MultiTransportData.() -> Unit
+
+/**
+ * A transport container an ECU can be attached to via [multiTransport]:
+ * [DoipEntityData] (gateway/doip entity) or [CanBusData]
+ */
+public sealed interface MultiTransportTarget
+
+/**
+ * DSL scope for defining ECUs that are attached to multiple transports at once
+ */
+public class MultiTransportData internal constructor(
+    private val targets: List<MultiTransportTarget>,
+) {
+    /**
+     * Defines an ECU that is reachable on all targets of this block. The ECU is a
+     * single instance: stored properties, timers, interceptors and the busy-state
+     * are shared across the transports.
+     *
+     * DoIP addressing ([CanEcuData.logicalAddress]/[CanEcuData.functionalAddress])
+     * and CAN addressing ([CanEcuData.requestId]/[CanEcuData.responseId]) must
+     * both be set when the respective transport is among the targets.
+     */
+    public fun ecu(name: String, receiver: CanEcuDataHandler) {
+        val ecuData = CanEcuData(name)
+        receiver.invoke(ecuData)
+        targets.forEach {
+            when (it) {
+                is DoipEntityData -> it.addEcu(ecuData)
+                is CanBusData -> it.addEcu(ecuData)
+            }
+        }
+    }
+}
+
+/**
+ * Attaches the ECUs defined in [receiver] to all of the given [targets]
+ * (DoIP entities and/or CAN buses), e.g.:
+ *
+ * ```
+ * network {
+ *     multiTransport(
+ *         gateway("GW") { logicalAddress = 0x1010 },
+ *         canBus("BUS1") { transport = socketCan("vcan0") },
+ *     ) {
+ *         ecu("ECU1") {
+ *             logicalAddress = 0x1011
+ *             requestId = 0x712
+ *             responseId = 0x7A2
+ *             request("22 F1 86") { respond("62 F1 86 01") }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+@Suppress("unused")
+public fun NetworkingData.multiTransport(vararg targets: MultiTransportTarget, receiver: MultiTransportDataHandler) {
+    require(targets.isNotEmpty()) {
+        "multiTransport requires at least one target"
+    }
+    require(targets.count { it is DoipEntityData } <= 1) {
+        "multiTransport supports at most one DoIP entity per block"
+    }
+    require(targets.distinct().size == targets.size) {
+        "multiTransport targets must be distinct"
+    }
+    receiver.invoke(MultiTransportData(targets.toList()))
+}

--- a/src/main/kotlin/SimNetworking.kt
+++ b/src/main/kotlin/SimNetworking.kt
@@ -1,5 +1,6 @@
 import library.*
 import org.slf4j.LoggerFactory
+import java.util.IdentityHashMap
 
 public enum class NetworkMode {
     AUTO,
@@ -46,29 +47,45 @@ public open class NetworkingData {
     public val doipEntities: List<DoipEntityData>
         get() = _doipEntities
 
+    internal val _canBuses: MutableList<CanBusData> = mutableListOf()
+
+    public val canBuses: List<CanBusData>
+        get() = _canBuses
+
     /**
      * Defines a DoIP-Gateway and the ECUs behind it
      */
-    public fun gateway(name: String, receiver: DoipEntityDataHandler) {
+    public fun gateway(name: String, receiver: DoipEntityDataHandler): DoipEntityData {
         val gatewayData = DoipEntityData(name, DoipNodeType.GATEWAY)
         receiver.invoke(gatewayData)
         _doipEntities.add(gatewayData)
+        return gatewayData
     }
 
     /**
      * Defines a DoIP-Gateway and the ECUs behind it
      */
-    public fun doipEntity(name: String, receiver: DoipEntityDataHandler) {
+    public fun doipEntity(name: String, receiver: DoipEntityDataHandler): DoipEntityData {
         val gatewayData = DoipEntityData(name, DoipNodeType.NODE)
         receiver.invoke(gatewayData)
         _doipEntities.add(gatewayData)
+        return gatewayData
     }
 
+    /**
+     * Defines a CAN bus and the ECUs on it, reachable via UDS over ISO-TP
+     */
+    public fun canBus(name: String, receiver: CanBusDataHandler): CanBusData {
+        val canBusData = CanBusData(name)
+        receiver.invoke(canBusData)
+        _canBuses.add(canBusData)
+        return canBusData
+    }
 }
 
 public open class SimDoipNetworking(data: NetworkingData) : SimNetworking<SimEcu, SimDoipEntity>(data) {
     override fun createDoipEntity(data: DoipEntityData): SimDoipEntity =
-        SimDoipEntity(data)
+        SimDoipEntity(data, sharedEcuInstances)
 }
 
 public abstract class SimNetworking<E : SimulatedEcu, out T : DoipEntity<E>>(public val data: NetworkingData) {
@@ -85,6 +102,22 @@ public abstract class SimNetworking<E : SimulatedEcu, out T : DoipEntity<E>>(pub
     private val _doipEntities: MutableList<T> = mutableListOf()
     protected val _vams: MutableList<DoipUdpVehicleAnnouncementMessage> = mutableListOf()
 
+    public val canBusBindings: List<CanBusBinding>
+        get() {
+            if (data.canBuses.isNotEmpty() && _canBusBindings.isEmpty()) {
+                start()
+            }
+            return _canBusBindings
+        }
+
+    private val _canBusBindings: MutableList<CanBusBinding> = mutableListOf()
+
+    /**
+     * One instance per [EcuData] object across all transports - an EcuData attached
+     * to multiple transports (multiTransport) results in a single shared [SimEcu]
+     */
+    protected val sharedEcuInstances: MutableMap<EcuData, SimEcu> = IdentityHashMap()
+
     protected fun addEntity(doipEntity: @UnsafeVariance T) {
         if (_doipEntities.any { it.config.logicalAddress == doipEntity.config.logicalAddress }) {
             log.error("Can't add '${doipEntity.name}' - entity with same logical address already exists")
@@ -96,22 +129,43 @@ public abstract class SimNetworking<E : SimulatedEcu, out T : DoipEntity<E>>(pub
     protected abstract fun createDoipEntity(data: DoipEntityData): T
 
     public open fun start() {
+        sharedEcuInstances.clear()
+
         _doipEntities.clear()
 
         data._doipEntities.map { createDoipEntity(it) }.forEach {
             _doipEntities.add(it)
         }
 
+        // entities first: they create (and own) the SimEcus, which the CAN bus
+        // bindings then adopt for ECUs attached to both transports (multiTransport)
         _doipEntities.forEach {
+            it.start()
+        }
+
+        _canBusBindings.clear()
+
+        data._canBuses.map { CanBusBinding(it, sharedEcuInstances) }.forEach {
+            _canBusBindings.add(it)
+        }
+
+        _canBusBindings.forEach {
             it.start()
         }
     }
 
     public open fun reset() {
         _doipEntities.forEach { it.reset() }
+        _canBusBindings.forEach { it.reset() }
     }
 
     public open fun findEcuByName(ecuName: String, ignoreCase: Boolean = true): E? =
         _doipEntities.flatMap { it.ecus }.firstOrNull { ecuName.equals(it.name, ignoreCase) }
+
+    /**
+     * Finds an ECU defined on one of the CAN buses by its name
+     */
+    public fun findCanEcuByName(ecuName: String, ignoreCase: Boolean = true): SimEcu? =
+        _canBusBindings.firstNotNullOfOrNull { it.findEcuByName(ecuName, ignoreCase) }
 }
 

--- a/src/main/kotlin/library/UdsMessage.kt
+++ b/src/main/kotlin/library/UdsMessage.kt
@@ -15,7 +15,7 @@ public open class UdsMessage(
         public const val FUNCTIONAL: Int = 1
     }
 
-    public fun respond(data: ByteArray) {
+    public open fun respond(data: ByteArray) {
         val response = DoipTcpDiagMessage(targetAddressPhysical, sourceAddress, data)
 
         runBlocking {

--- a/src/main/kotlin/library/can/CanFrame.kt
+++ b/src/main/kotlin/library/can/CanFrame.kt
@@ -1,0 +1,68 @@
+package library.can
+
+import library.toHexString
+
+/**
+ * A single CAN frame as seen on the bus.
+ */
+public class CanFrame(
+    /**
+     * Raw CAN identifier (11-bit standard, or 29-bit when [extended] is set)
+     */
+    public val id: Int,
+    public val data: ByteArray,
+    /**
+     * CAN FD frame (payload up to 64 bytes)
+     */
+    public val fd: Boolean = false,
+    /**
+     * 29-bit extended identifier
+     */
+    public val extended: Boolean = false,
+) {
+    init {
+        require(data.size <= if (fd) MAX_FD_DATA_LENGTH else MAX_DATA_LENGTH) {
+            "CAN frame payload is too large (${data.size} bytes, fd=$fd)"
+        }
+        require(id <= if (extended) MAX_EXTENDED_ID else MAX_STANDARD_ID) {
+            "CAN id ${id.toString(16)} out of range (extended=$extended)"
+        }
+    }
+
+    override fun toString(): String =
+        "CanFrame(id=0x${id.toString(16)}, data=${data.toHexString(limit = 16)}${if (fd) ", fd" else ""}${if (extended) ", eff" else ""})"
+
+    public companion object {
+        public const val MAX_DATA_LENGTH: Int = 8
+        public const val MAX_FD_DATA_LENGTH: Int = 64
+        public const val MAX_STANDARD_ID: Int = 0x7FF
+        public const val MAX_EXTENDED_ID: Int = 0x1FFFFFFF
+    }
+}
+
+/**
+ * Valid CAN(-FD) frame payload lengths and padding
+ */
+public object CanDlc {
+    private val validLengths = intArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64)
+
+    public fun isValidLength(length: Int): Boolean =
+        validLengths.contains(length)
+
+    /**
+     * Returns the smallest valid CAN(-FD) frame length that can hold [length] bytes
+     */
+    public fun nextValidLength(length: Int): Int =
+        validLengths.firstOrNull { it >= length }
+            ?: throw IllegalArgumentException("No valid CAN frame length for $length bytes")
+
+    /**
+     * Pads [data] with [paddingByte] up to [length] (returns [data] unchanged if it's already long enough)
+     */
+    public fun pad(data: ByteArray, length: Int, paddingByte: Byte): ByteArray =
+        if (data.size >= length) {
+            data
+        } else {
+            data.copyOf(length).also { it.fill(paddingByte, data.size, length) }
+        }
+}

--- a/src/main/kotlin/library/can/CanTransport.kt
+++ b/src/main/kotlin/library/can/CanTransport.kt
@@ -1,0 +1,61 @@
+package library.can
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Abstraction over a raw CAN bus connection (frame in/out), implemented by
+ * SocketCAN, socketcand and loopback transports.
+ */
+public interface CanTransport : AutoCloseable {
+    /**
+     * Name of the transport (used in logs and thread names)
+     */
+    public val name: String
+
+    /**
+     * Whether this transport can send/receive CAN FD frames
+     */
+    public val supportsFd: Boolean
+
+    /**
+     * Hot stream of all frames received from the bus
+     */
+    public val incomingFrames: SharedFlow<CanFrame>
+
+    /**
+     * Connect/bind the transport and start reading frames into [incomingFrames] within [scope]
+     */
+    public suspend fun start(scope: CoroutineScope)
+
+    public suspend fun sendFrame(frame: CanFrame)
+
+    override fun close()
+}
+
+/**
+ * In-memory CAN bus: every sent frame is echoed to all subscribers of [incomingFrames].
+ * Useful for unit tests and simulations without any real CAN stack.
+ */
+public class LoopbackCanTransport(
+    override val name: String = "loopback",
+    override val supportsFd: Boolean = true,
+    bufferCapacity: Int = 1024,
+) : CanTransport {
+    private val _incomingFrames = MutableSharedFlow<CanFrame>(extraBufferCapacity = bufferCapacity)
+
+    override val incomingFrames: SharedFlow<CanFrame> = _incomingFrames
+
+    override suspend fun start(scope: CoroutineScope) {
+        // nothing to do
+    }
+
+    override suspend fun sendFrame(frame: CanFrame) {
+        _incomingFrames.emit(frame)
+    }
+
+    override fun close() {
+        // nothing to do
+    }
+}

--- a/src/main/kotlin/library/can/CanUdsMessage.kt
+++ b/src/main/kotlin/library/can/CanUdsMessage.kt
@@ -1,0 +1,40 @@
+package library.can
+
+import kotlinx.coroutines.runBlocking
+import library.OutputChannel
+import library.UdsMessage
+
+/**
+ * A UDS message received via ISO-TP on a CAN bus.
+ *
+ * The inherited [sourceAddress]/[targetAddress] fields are truncated to [Short]
+ * for compatibility with the DoIP-based API; [requestCanId] and [responseCanId]
+ * carry the unmodified CAN identifiers.
+ */
+public class CanUdsMessage(
+    targetAddressType: Int,
+    message: ByteArray,
+    output: OutputChannel,
+    /**
+     * CAN id the request was received on (physical or functional)
+     */
+    public val requestCanId: Int,
+    /**
+     * CAN id the response is sent on
+     */
+    public val responseCanId: Int,
+) : UdsMessage(
+    sourceAddress = requestCanId.toShort(),
+    targetAddress = requestCanId.toShort(),
+    targetAddressType = targetAddressType,
+    targetAddressPhysical = responseCanId.toShort(),
+    message = message,
+    output = output,
+) {
+    override fun respond(data: ByteArray) {
+        // no transport header - the output channel performs a complete ISO-TP transmission
+        runBlocking {
+            output.writeFully(data)
+        }
+    }
+}

--- a/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
+++ b/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
@@ -106,6 +106,8 @@ public class IsoTpEndpoint(
         var offset = ffPayloadSize
         var sequenceNumber = 1
         var waitCount = 0
+        // STmin separates consecutive frames; it doesn't apply before the very first one
+        var consecutiveFramesSent = false
         while (offset < payload.size) {
             val fc = withTimeoutOrNull(options.nBsTimeout) { flowControls.receive() }
                 ?: throw IsoTpException("Timeout waiting for flow control while sending on 0x${txId.toString(16)} (N_Bs)")
@@ -115,7 +117,7 @@ public class IsoTpEndpoint(
                     val stMinMillis = IsoTpFraming.stMinToMillis(fc.stMin)
                     var framesInBlock = 0
                     while (offset < payload.size && (fc.blockSize == 0 || framesInBlock < fc.blockSize)) {
-                        if (stMinMillis > 0) {
+                        if (stMinMillis > 0 && consecutiveFramesSent) {
                             delay(stMinMillis)
                         }
                         val chunk = payload.copyOfRange(offset, minOf(offset + cfPayloadSize, payload.size))
@@ -123,6 +125,7 @@ public class IsoTpEndpoint(
                         sequenceNumber = (sequenceNumber + 1) and 0x0F
                         offset += chunk.size
                         framesInBlock++
+                        consecutiveFramesSent = true
                     }
                 }
                 WAIT -> {
@@ -139,19 +142,32 @@ public class IsoTpEndpoint(
 
     private class ReceivedPdu(val pdu: IsoTpPdu, val functional: Boolean)
 
-    private suspend fun receivePdu(timeout: kotlin.time.Duration? = null): ReceivedPdu? {
-        val frame = if (timeout == null) {
-            frames.receive()
-        } else {
-            withTimeoutOrNull(timeout) { frames.receive() } ?: return null
+    /**
+     * Suspends until a decodable ISO-TP frame arrives, skipping (and logging)
+     * undecodable frames so a single corrupt frame doesn't abort a reception
+     */
+    private suspend fun receiveDecodablePdu(): ReceivedPdu {
+        while (true) {
+            val frame = frames.receive()
+            val pdu = IsoTpFraming.decode(frame.data)
+            if (pdu == null) {
+                logger.warn("Ignoring invalid ISO-TP frame on 0x${frame.id.toString(16)}: ${frame.data.toHexString(limit = 10)}")
+                continue
+            }
+            return ReceivedPdu(pdu, functional = functionalRxId != null && frame.id == functionalRxId && frame.id != physicalRxId)
         }
-        val pdu = IsoTpFraming.decode(frame.data)
-        if (pdu == null) {
-            logger.warn("Ignoring invalid ISO-TP frame on 0x${frame.id.toString(16)}: ${frame.data.toHexString(limit = 10)}")
-            return null
-        }
-        return ReceivedPdu(pdu, functional = functionalRxId != null && frame.id == functionalRxId && frame.id != physicalRxId)
     }
+
+    /**
+     * Returns the next decodable PDU, or null only when [timeout] elapses first
+     * (a null result always means a timeout, never a malformed frame)
+     */
+    private suspend fun receivePdu(timeout: kotlin.time.Duration? = null): ReceivedPdu? =
+        if (timeout == null) {
+            receiveDecodablePdu()
+        } else {
+            withTimeoutOrNull(timeout) { receiveDecodablePdu() }
+        }
 
     private suspend fun processPdu(received: ReceivedPdu) {
         val pdu = received.pdu

--- a/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
+++ b/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
@@ -1,5 +1,6 @@
 package library.can.isotp
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -64,7 +65,17 @@ public class IsoTpEndpoint(
         }
         jobs += scope.launch {
             while (currentCoroutineContext().isActive) {
-                processPdu(receivePdu() ?: continue)
+                val received = receivePdu() ?: continue
+                try {
+                    processPdu(received)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // a failing transport send (e.g. flow control while socketcand is
+                    // reconnecting) must not kill the processing loop - the endpoint has
+                    // to keep serving frames once the transport is available again
+                    logger.error("Error while processing an ISO-TP frame on 0x${physicalRxId.toString(16)}", e)
+                }
             }
         }
     }

--- a/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
+++ b/src/main/kotlin/library/can/isotp/IsoTpEndpoint.kt
@@ -1,0 +1,242 @@
+package library.can.isotp
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import library.OutputChannel
+import library.can.CanFrame
+import library.can.CanTransport
+import library.can.isotp.IsoTpFlowControlFrame.Companion.CONTINUE_TO_SEND
+import library.can.isotp.IsoTpFlowControlFrame.Companion.OVERFLOW
+import library.can.isotp.IsoTpFlowControlFrame.Companion.WAIT
+import library.toHexString
+import org.slf4j.LoggerFactory
+
+public class IsoTpException(message: String) : Exception(message)
+
+/**
+ * One ISO-TP endpoint on a CAN bus: receives segmented messages addressed to
+ * [physicalRxId] (and single frames to [functionalRxId]), reassembles them and
+ * hands them to [handler]; transmits segmented messages on [txId].
+ *
+ * [handler] is invoked on the endpoint's frame-processing coroutine and must not
+ * block - dispatch the actual work to another coroutine (otherwise flow control
+ * frames for concurrently transmitted responses can't be processed).
+ */
+public class IsoTpEndpoint(
+    private val transport: CanTransport,
+    private val physicalRxId: Int,
+    private val functionalRxId: Int?,
+    private val txId: Int,
+    private val options: IsoTpOptions,
+    private val handler: (payload: ByteArray, functional: Boolean) -> Unit,
+) {
+    private val logger = LoggerFactory.getLogger(IsoTpEndpoint::class.java)
+
+    private val frames = Channel<CanFrame>(Channel.UNLIMITED)
+    private val flowControls = Channel<IsoTpFlowControlFrame>(Channel.UNLIMITED)
+    private val txMutex = Mutex()
+    private val jobs = mutableListOf<Job>()
+
+    /**
+     * Response path for [library.UdsMessage] - writing to it performs a full
+     * (possibly segmented) ISO-TP transmission
+     */
+    public val outputChannel: OutputChannel = IsoTpOutputChannel()
+
+    public fun start(scope: CoroutineScope) {
+        // UNDISPATCHED so the subscription to the (non-buffering) shared flow is
+        // already registered when start() returns - frames sent afterwards can't be lost
+        jobs += scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            transport.incomingFrames.collect { frame ->
+                if (frame.id == physicalRxId || (functionalRxId != null && frame.id == functionalRxId)) {
+                    frames.send(frame)
+                }
+            }
+        }
+        jobs += scope.launch {
+            while (currentCoroutineContext().isActive) {
+                processPdu(receivePdu() ?: continue)
+            }
+        }
+    }
+
+    public fun stop() {
+        jobs.forEach { it.cancel() }
+        jobs.clear()
+    }
+
+    /**
+     * Transmits a complete ISO-TP message on [txId], segmenting it and honoring
+     * the receiver's flow control if it doesn't fit a single frame.
+     * Concurrent calls are serialized.
+     */
+    public suspend fun send(payload: ByteArray) {
+        txMutex.withLock {
+            if (payload.size <= IsoTpFraming.maxSingleFramePayload(options)) {
+                sendData(IsoTpFraming.encodeSingleFrame(payload, options))
+            } else {
+                sendSegmented(payload)
+            }
+        }
+    }
+
+    private suspend fun sendData(data: ByteArray) {
+        transport.sendFrame(IsoTpFraming.toCanFrame(txId, data, options))
+    }
+
+    private suspend fun sendSegmented(payload: ByteArray) {
+        // drop stale flow control frames from a previous (possibly aborted) transmission
+        while (flowControls.tryReceive().isSuccess) {
+            // drain
+        }
+
+        val ffPayloadSize = IsoTpFraming.firstFramePayloadSize(payload.size, options)
+        val cfPayloadSize = IsoTpFraming.consecutiveFramePayloadSize(options)
+        sendData(IsoTpFraming.encodeFirstFrame(payload.size, payload.copyOfRange(0, ffPayloadSize), options))
+
+        var offset = ffPayloadSize
+        var sequenceNumber = 1
+        var waitCount = 0
+        while (offset < payload.size) {
+            val fc = withTimeoutOrNull(options.nBsTimeout) { flowControls.receive() }
+                ?: throw IsoTpException("Timeout waiting for flow control while sending on 0x${txId.toString(16)} (N_Bs)")
+            when (fc.status) {
+                CONTINUE_TO_SEND -> {
+                    waitCount = 0
+                    val stMinMillis = IsoTpFraming.stMinToMillis(fc.stMin)
+                    var framesInBlock = 0
+                    while (offset < payload.size && (fc.blockSize == 0 || framesInBlock < fc.blockSize)) {
+                        if (stMinMillis > 0) {
+                            delay(stMinMillis)
+                        }
+                        val chunk = payload.copyOfRange(offset, minOf(offset + cfPayloadSize, payload.size))
+                        sendData(IsoTpFraming.encodeConsecutiveFrame(sequenceNumber, chunk, options))
+                        sequenceNumber = (sequenceNumber + 1) and 0x0F
+                        offset += chunk.size
+                        framesInBlock++
+                    }
+                }
+                WAIT -> {
+                    waitCount++
+                    if (waitCount > options.maxWaitFrames) {
+                        throw IsoTpException("Receiver sent more than ${options.maxWaitFrames} flow control WAIT frames, aborting transmission on 0x${txId.toString(16)}")
+                    }
+                }
+                OVERFLOW ->
+                    throw IsoTpException("Receiver signaled flow control OVERFLOW for transmission on 0x${txId.toString(16)}")
+            }
+        }
+    }
+
+    private class ReceivedPdu(val pdu: IsoTpPdu, val functional: Boolean)
+
+    private suspend fun receivePdu(timeout: kotlin.time.Duration? = null): ReceivedPdu? {
+        val frame = if (timeout == null) {
+            frames.receive()
+        } else {
+            withTimeoutOrNull(timeout) { frames.receive() } ?: return null
+        }
+        val pdu = IsoTpFraming.decode(frame.data)
+        if (pdu == null) {
+            logger.warn("Ignoring invalid ISO-TP frame on 0x${frame.id.toString(16)}: ${frame.data.toHexString(limit = 10)}")
+            return null
+        }
+        return ReceivedPdu(pdu, functional = functionalRxId != null && frame.id == functionalRxId && frame.id != physicalRxId)
+    }
+
+    private suspend fun processPdu(received: ReceivedPdu) {
+        val pdu = received.pdu
+        when (pdu) {
+            is IsoTpSingleFrame ->
+                handler(pdu.payload, received.functional)
+            is IsoTpFirstFrame ->
+                if (received.functional) {
+                    logger.warn("Ignoring first frame on functional id 0x${functionalRxId?.toString(16)} - segmented functional requests aren't allowed")
+                } else {
+                    receiveSegmented(pdu)
+                }
+            is IsoTpConsecutiveFrame ->
+                logger.warn("Ignoring unexpected consecutive frame on 0x${physicalRxId.toString(16)} - no reception in progress")
+            is IsoTpFlowControlFrame ->
+                flowControls.send(pdu)
+        }
+    }
+
+    private suspend fun receiveSegmented(firstFrame: IsoTpFirstFrame) {
+        if (firstFrame.totalLength > options.maxMessageSize) {
+            logger.warn("Rejecting incoming message of ${firstFrame.totalLength} bytes on 0x${physicalRxId.toString(16)} (maxMessageSize = ${options.maxMessageSize})")
+            sendData(IsoTpFraming.encodeFlowControlFrame(OVERFLOW, 0, 0, options))
+            return
+        }
+        val buffer = ByteArray(firstFrame.totalLength)
+        var received = minOf(firstFrame.payload.size, buffer.size)
+        firstFrame.payload.copyInto(buffer, 0, 0, received)
+
+        sendData(IsoTpFraming.encodeFlowControlFrame(CONTINUE_TO_SEND, options.blockSize, options.stMin, options))
+        var expectedSequenceNumber = 1
+        var framesUntilFlowControl = options.blockSize
+
+        while (received < buffer.size) {
+            val next = receivePdu(options.nCrTimeout)
+            if (next == null) {
+                logger.warn("Aborting reception on 0x${physicalRxId.toString(16)} ($received/${buffer.size} bytes received)")
+                return
+            }
+            when (val pdu = next.pdu) {
+                is IsoTpConsecutiveFrame -> {
+                    if (next.functional) {
+                        logger.warn("Ignoring consecutive frame on functional id")
+                        continue
+                    }
+                    if (pdu.sequenceNumber != expectedSequenceNumber) {
+                        logger.warn("Aborting reception on 0x${physicalRxId.toString(16)}: expected sequence number $expectedSequenceNumber, got ${pdu.sequenceNumber}")
+                        return
+                    }
+                    val chunk = minOf(pdu.payload.size, buffer.size - received)
+                    pdu.payload.copyInto(buffer, received, 0, chunk)
+                    received += chunk
+                    expectedSequenceNumber = (expectedSequenceNumber + 1) and 0x0F
+                    if (framesUntilFlowControl > 0 && received < buffer.size) {
+                        framesUntilFlowControl--
+                        if (framesUntilFlowControl == 0) {
+                            sendData(IsoTpFraming.encodeFlowControlFrame(CONTINUE_TO_SEND, options.blockSize, options.stMin, options))
+                            framesUntilFlowControl = options.blockSize
+                        }
+                    }
+                }
+                is IsoTpFlowControlFrame ->
+                    // flow control for a transmission running concurrently to this reception
+                    flowControls.send(pdu)
+                is IsoTpSingleFrame, is IsoTpFirstFrame -> {
+                    if (next.functional && pdu is IsoTpSingleFrame) {
+                        handler(pdu.payload, true)
+                        continue
+                    }
+                    logger.warn("New ISO-TP message while reception on 0x${physicalRxId.toString(16)} was in progress - restarting")
+                    processPdu(next)
+                    return
+                }
+            }
+        }
+        handler(buffer, false)
+    }
+
+    private inner class IsoTpOutputChannel : OutputChannel {
+        override suspend fun writeFully(data: ByteArray) {
+            send(data)
+        }
+
+        override suspend fun flush() {
+            // each write is already a complete ISO-TP transmission
+        }
+    }
+}

--- a/src/main/kotlin/library/can/isotp/IsoTpFraming.kt
+++ b/src/main/kotlin/library/can/isotp/IsoTpFraming.kt
@@ -1,0 +1,194 @@
+package library.can.isotp
+
+import library.can.CanDlc
+import library.can.CanFrame
+
+public sealed class IsoTpPdu
+
+public class IsoTpSingleFrame(public val payload: ByteArray) : IsoTpPdu()
+
+public class IsoTpFirstFrame(public val totalLength: Int, public val payload: ByteArray) : IsoTpPdu()
+
+public class IsoTpConsecutiveFrame(public val sequenceNumber: Int, public val payload: ByteArray) : IsoTpPdu()
+
+public class IsoTpFlowControlFrame(public val status: Int, public val blockSize: Int, public val stMin: Int) : IsoTpPdu() {
+    public companion object {
+        public const val CONTINUE_TO_SEND: Int = 0
+        public const val WAIT: Int = 1
+        public const val OVERFLOW: Int = 2
+    }
+}
+
+/**
+ * Stateless encoding/decoding of ISO 15765-2 protocol data units, including the
+ * CAN FD escape encodings (SF_DL escape byte, 32-bit FF_DL)
+ */
+public object IsoTpFraming {
+    internal const val PCI_SINGLE_FRAME = 0x0
+    internal const val PCI_FIRST_FRAME = 0x1
+    internal const val PCI_CONSECUTIVE_FRAME = 0x2
+    internal const val PCI_FLOW_CONTROL = 0x3
+
+    private const val MAX_FF_DL_12BIT = 0xFFF
+    private const val DEFAULT_FD_PADDING = 0xCC.toByte()
+
+    /**
+     * Decodes the data bytes of a CAN frame into an ISO-TP PDU, or null when the
+     * content isn't a valid ISO-TP frame
+     */
+    public fun decode(data: ByteArray): IsoTpPdu? {
+        if (data.isEmpty()) {
+            return null
+        }
+        val b0 = data[0].toInt() and 0xFF
+        return when (b0 shr 4) {
+            PCI_SINGLE_FRAME -> decodeSingleFrame(data, b0)
+            PCI_FIRST_FRAME -> decodeFirstFrame(data, b0)
+            PCI_CONSECUTIVE_FRAME -> IsoTpConsecutiveFrame(b0 and 0x0F, data.copyOfRange(1, data.size))
+            PCI_FLOW_CONTROL ->
+                if (data.size < 3 || (b0 and 0x0F) > IsoTpFlowControlFrame.OVERFLOW) {
+                    null
+                } else {
+                    IsoTpFlowControlFrame(b0 and 0x0F, data[1].toInt() and 0xFF, data[2].toInt() and 0xFF)
+                }
+            else -> null
+        }
+    }
+
+    private fun decodeSingleFrame(data: ByteArray, b0: Int): IsoTpSingleFrame? {
+        if (b0 == 0x00) {
+            // CAN FD escape: SF_DL in the second byte
+            if (data.size < 2) {
+                return null
+            }
+            val sfdl = data[1].toInt() and 0xFF
+            if (sfdl == 0 || 2 + sfdl > data.size) {
+                return null
+            }
+            return IsoTpSingleFrame(data.copyOfRange(2, 2 + sfdl))
+        }
+        val sfdl = b0 and 0x0F
+        if (sfdl > 7 || 1 + sfdl > data.size) {
+            return null
+        }
+        return IsoTpSingleFrame(data.copyOfRange(1, 1 + sfdl))
+    }
+
+    private fun decodeFirstFrame(data: ByteArray, b0: Int): IsoTpFirstFrame? {
+        if (data.size < 2) {
+            return null
+        }
+        val ffdl12 = ((b0 and 0x0F) shl 8) or (data[1].toInt() and 0xFF)
+        if (ffdl12 != 0) {
+            return IsoTpFirstFrame(ffdl12, data.copyOfRange(2, data.size))
+        }
+        // 32-bit FF_DL escape
+        if (data.size < 7) {
+            return null
+        }
+        val ffdl = ((data[2].toInt() and 0xFF) shl 24) or
+                ((data[3].toInt() and 0xFF) shl 16) or
+                ((data[4].toInt() and 0xFF) shl 8) or
+                (data[5].toInt() and 0xFF)
+        if (ffdl <= MAX_FF_DL_12BIT) {
+            return null
+        }
+        return IsoTpFirstFrame(ffdl, data.copyOfRange(6, data.size))
+    }
+
+    /**
+     * Maximum payload that fits into a single frame with the given options
+     */
+    public fun maxSingleFramePayload(options: IsoTpOptions): Int =
+        if (options.fd && options.txDlc > 8) {
+            options.txDlc - 2
+        } else {
+            minOf(options.txDlc, 8) - 1
+        }
+
+    /**
+     * Number of payload bytes carried by the first frame
+     */
+    public fun firstFramePayloadSize(totalLength: Int, options: IsoTpOptions): Int =
+        if (totalLength > MAX_FF_DL_12BIT) options.txDlc - 6 else options.txDlc - 2
+
+    /**
+     * Maximum number of payload bytes per consecutive frame
+     */
+    public fun consecutiveFramePayloadSize(options: IsoTpOptions): Int =
+        options.txDlc - 1
+
+    public fun encodeSingleFrame(payload: ByteArray, options: IsoTpOptions): ByteArray {
+        require(payload.size <= maxSingleFramePayload(options)) {
+            "Payload too large for a single frame (${payload.size} bytes)"
+        }
+        val frame = if (payload.size <= 7) {
+            byteArrayOf((PCI_SINGLE_FRAME shl 4 or payload.size).toByte(), *payload)
+        } else {
+            byteArrayOf(0x00, payload.size.toByte(), *payload)
+        }
+        return padFrame(frame, options)
+    }
+
+    public fun encodeFirstFrame(totalLength: Int, payload: ByteArray, options: IsoTpOptions): ByteArray {
+        require(payload.size == firstFramePayloadSize(totalLength, options))
+        return if (totalLength <= MAX_FF_DL_12BIT) {
+            byteArrayOf(
+                (PCI_FIRST_FRAME shl 4 or (totalLength shr 8)).toByte(),
+                (totalLength and 0xFF).toByte(),
+                *payload
+            )
+        } else {
+            byteArrayOf(
+                (PCI_FIRST_FRAME shl 4).toByte(),
+                0x00,
+                (totalLength shr 24).toByte(),
+                (totalLength shr 16 and 0xFF).toByte(),
+                (totalLength shr 8 and 0xFF).toByte(),
+                (totalLength and 0xFF).toByte(),
+                *payload
+            )
+        }
+    }
+
+    public fun encodeConsecutiveFrame(sequenceNumber: Int, payload: ByteArray, options: IsoTpOptions): ByteArray {
+        require(payload.size <= consecutiveFramePayloadSize(options))
+        return padFrame(byteArrayOf((PCI_CONSECUTIVE_FRAME shl 4 or (sequenceNumber and 0x0F)).toByte(), *payload), options)
+    }
+
+    public fun encodeFlowControlFrame(status: Int, blockSize: Int, stMin: Int, options: IsoTpOptions): ByteArray =
+        // flow control always fits a classic frame, padFrame caps padding at 8 bytes
+        padFrame(
+            byteArrayOf(
+                (PCI_FLOW_CONTROL shl 4 or status).toByte(),
+                blockSize.toByte(),
+                stMin.toByte()
+            ),
+            options
+        )
+
+    private fun padFrame(frame: ByteArray, options: IsoTpOptions): ByteArray =
+        if (options.fd && frame.size > 8) {
+            // FD frames must be padded up to the next valid frame length
+            CanDlc.pad(frame, CanDlc.nextValidLength(frame.size), options.paddingByte ?: DEFAULT_FD_PADDING)
+        } else if (options.paddingByte != null) {
+            CanDlc.pad(frame, minOf(options.txDlc, 8), options.paddingByte!!)
+        } else {
+            frame
+        }
+
+    /**
+     * Delay to honor for an STmin byte value: 0x00-0x7F = milliseconds,
+     * 0xF1-0xF9 = 100-900 µs (rounded up to 1 ms here); reserved values are
+     * treated as the maximum of 127 ms as required by ISO 15765-2
+     */
+    public fun stMinToMillis(stMin: Int): Long =
+        when (stMin) {
+            in 0x00..0x7F -> stMin.toLong()
+            in 0xF1..0xF9 -> 1L
+            else -> 0x7FL
+        }
+
+    internal fun toCanFrame(id: Int, data: ByteArray, options: IsoTpOptions): CanFrame =
+        CanFrame(id = id, data = data, fd = options.fd && data.size > 8)
+}

--- a/src/main/kotlin/library/can/isotp/IsoTpOptions.kt
+++ b/src/main/kotlin/library/can/isotp/IsoTpOptions.kt
@@ -1,0 +1,68 @@
+package library.can.isotp
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * ISO-TP (ISO 15765-2) parameters for one endpoint.
+ *
+ * Note: this implementation deliberately omits the N_As/N_Ar timeouts (transmit
+ * confirmation isn't observable above the raw frame transports) and never sends
+ * flow control WAIT frames itself (a simulator can always allocate the buffer).
+ */
+public class IsoTpOptions(
+    /**
+     * Block size announced in flow control frames we send while receiving
+     * (0 = all consecutive frames without further flow control)
+     */
+    public var blockSize: Int = 0,
+    /**
+     * STmin announced in flow control frames we send while receiving.
+     * Raw byte value: 0x00-0x7F = milliseconds, 0xF1-0xF9 = 100-900 µs
+     * (sub-millisecond values are rounded up to 1 ms when honoring them)
+     */
+    public var stMin: Int = 0,
+    /**
+     * Maximum payload length of transmitted frames (tx_dl): 8 for classic CAN,
+     * up to 64 (12, 16, 20, 24, 32, 48, 64) with CAN FD
+     */
+    public var txDlc: Int = 8,
+    /**
+     * Byte used to pad transmitted frames (null = no padding; CAN FD frames are
+     * always padded up to the next valid frame length)
+     */
+    public var paddingByte: Byte? = 0xCC.toByte(),
+    /**
+     * Use CAN FD framing (escape DLC, payloads > 8 bytes per frame)
+     */
+    public var fd: Boolean = false,
+    /**
+     * Timeout waiting for a flow control frame after sending a first frame / block (N_Bs)
+     */
+    public var nBsTimeout: Duration = 1.seconds,
+    /**
+     * Timeout waiting for the next consecutive frame while receiving (N_Cr)
+     */
+    public var nCrTimeout: Duration = 1.seconds,
+    /**
+     * Maximum number of flow control WAIT frames accepted before aborting a transmission (WFTmax)
+     */
+    public var maxWaitFrames: Int = 8,
+    /**
+     * Maximum size of a single received message before answering with flow control OVERFLOW
+     */
+    public var maxMessageSize: Int = 8 * 1024 * 1024,
+) {
+    public fun copy(): IsoTpOptions =
+        IsoTpOptions(
+            blockSize = blockSize,
+            stMin = stMin,
+            txDlc = txDlc,
+            paddingByte = paddingByte,
+            fd = fd,
+            nBsTimeout = nBsTimeout,
+            nCrTimeout = nCrTimeout,
+            maxWaitFrames = maxWaitFrames,
+            maxMessageSize = maxMessageSize,
+        )
+}

--- a/src/main/kotlin/library/can/socketcan/SocketCanTransport.kt
+++ b/src/main/kotlin/library/can/socketcan/SocketCanTransport.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import library.can.CanFrame
 import library.can.CanTransport
@@ -38,6 +40,7 @@ public class SocketCanTransport(
     override val incomingFrames: SharedFlow<CanFrame> = _incomingFrames
 
     private val closed = AtomicBoolean(false)
+    private val writeMutex = Mutex()
 
     @Volatile
     private var channel: RawCanChannel? = null
@@ -71,7 +74,9 @@ public class SocketCanTransport(
             JavaCanFrame.create(frame.id, flags, frame.data)
         }
         withContext(Dispatchers.IO) {
-            channel.write(javaCanFrame)
+            writeMutex.withLock {
+                channel.write(javaCanFrame)
+            }
         }
     }
 

--- a/src/main/kotlin/library/can/socketcan/SocketCanTransport.kt
+++ b/src/main/kotlin/library/can/socketcan/SocketCanTransport.kt
@@ -1,0 +1,106 @@
+package library.can.socketcan
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import library.can.CanFrame
+import library.can.CanTransport
+import org.slf4j.LoggerFactory
+import tel.schich.javacan.CanChannels
+import tel.schich.javacan.CanSocketOptions
+import tel.schich.javacan.NetworkDevice
+import tel.schich.javacan.RawCanChannel
+import java.util.concurrent.atomic.AtomicBoolean
+import tel.schich.javacan.CanFrame as JavaCanFrame
+
+/**
+ * CAN transport using a SocketCAN raw socket via the optional
+ * `tel.schich:javacan-core` dependency (Linux only). Works with any SocketCAN
+ * network device: real hardware, vcan and vxcan pairs.
+ */
+public class SocketCanTransport(
+    private val interfaceName: String,
+    private val enableFd: Boolean = false,
+) : CanTransport {
+    private val logger = LoggerFactory.getLogger(SocketCanTransport::class.java)
+
+    override val name: String = "socketcan://$interfaceName"
+
+    override val supportsFd: Boolean = true
+
+    private val _incomingFrames = MutableSharedFlow<CanFrame>(extraBufferCapacity = 1024)
+
+    override val incomingFrames: SharedFlow<CanFrame> = _incomingFrames
+
+    private val closed = AtomicBoolean(false)
+
+    @Volatile
+    private var channel: RawCanChannel? = null
+
+    override suspend fun start(scope: CoroutineScope) {
+        val channel = withContext(Dispatchers.IO) {
+            val ch = CanChannels.newRawChannel()
+            try {
+                ch.bind(NetworkDevice.lookup(interfaceName))
+                if (enableFd) {
+                    ch.setOption(CanSocketOptions.FD_FRAMES, true)
+                }
+            } catch (e: Exception) {
+                ch.close()
+                throw e
+            }
+            ch
+        }
+        this.channel = channel
+        scope.launch(Dispatchers.IO) {
+            readLoop(channel)
+        }
+    }
+
+    override suspend fun sendFrame(frame: CanFrame) {
+        val channel = this.channel ?: throw IllegalStateException("Not connected to $name")
+        val flags = if (frame.fd) JavaCanFrame.FD_FLAG_FD_FRAME else JavaCanFrame.FD_NO_FLAGS
+        val javaCanFrame = if (frame.extended) {
+            JavaCanFrame.createExtended(frame.id, flags, frame.data)
+        } else {
+            JavaCanFrame.create(frame.id, flags, frame.data)
+        }
+        withContext(Dispatchers.IO) {
+            channel.write(javaCanFrame)
+        }
+    }
+
+    override fun close() {
+        closed.set(true)
+        channel?.close()
+        channel = null
+    }
+
+    private suspend fun readLoop(channel: RawCanChannel) {
+        while (!closed.get() && currentCoroutineContext().isActive) {
+            val frame = try {
+                channel.read()
+            } catch (e: Exception) {
+                if (!closed.get()) {
+                    logger.error("Error reading from $name, stopping", e)
+                }
+                break
+            }
+            val data = ByteArray(frame.dataLength)
+            frame.getData(data, 0, data.size)
+            _incomingFrames.emit(
+                CanFrame(
+                    id = frame.id,
+                    data = data,
+                    fd = frame.isFDFrame,
+                    extended = frame.isExtended,
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/library/can/socketcand/SocketcandProtocol.kt
+++ b/src/main/kotlin/library/can/socketcand/SocketcandProtocol.kt
@@ -1,0 +1,107 @@
+package library.can.socketcand
+
+import library.can.CanFrame
+
+internal sealed class SocketcandMessage {
+    object Hi : SocketcandMessage()
+    object Ok : SocketcandMessage()
+    class Error(val text: String) : SocketcandMessage()
+    class Frame(val frame: CanFrame, val timestamp: Double) : SocketcandMessage()
+    class Unknown(val raw: String) : SocketcandMessage()
+}
+
+/**
+ * Incrementally extracts `< ... >` messages from a TCP byte stream
+ * (messages may arrive split or coalesced across reads)
+ */
+internal class SocketcandTokenizer {
+    private val buffer = StringBuilder()
+
+    fun feed(chunk: String): List<String> {
+        buffer.append(chunk)
+        val messages = mutableListOf<String>()
+        while (true) {
+            val start = buffer.indexOf('<')
+            if (start < 0) {
+                buffer.setLength(0)
+                break
+            }
+            val end = buffer.indexOf('>', start)
+            if (end < 0) {
+                if (start > 0) {
+                    buffer.delete(0, start)
+                }
+                break
+            }
+            messages.add(buffer.substring(start, end + 1))
+            buffer.delete(0, end + 1)
+        }
+        return messages
+    }
+}
+
+/**
+ * Parsing/serializing of the socketcand rawmode protocol messages
+ * (https://github.com/linux-can/socketcand/blob/master/doc/protocol.md)
+ */
+internal object SocketcandProtocol {
+    const val DEFAULT_PORT: Int = 29536
+
+    fun parse(message: String): SocketcandMessage {
+        val tokens = message.trim()
+            .removePrefix("<")
+            .removeSuffix(">")
+            .split(' ', '\t', '\n', '\r')
+            .filter { it.isNotEmpty() }
+        if (tokens.isEmpty()) {
+            return SocketcandMessage.Unknown(message)
+        }
+        return when (tokens[0]) {
+            "hi" -> SocketcandMessage.Hi
+            "ok" -> SocketcandMessage.Ok
+            "error" -> SocketcandMessage.Error(tokens.drop(1).joinToString(" "))
+            "frame" -> parseFrame(tokens) ?: SocketcandMessage.Unknown(message)
+            else -> SocketcandMessage.Unknown(message)
+        }
+    }
+
+    private fun parseFrame(tokens: List<String>): SocketcandMessage.Frame? {
+        // < frame can_id seconds.usecs data >
+        if (tokens.size < 3) {
+            return null
+        }
+        val idToken = tokens[1]
+        val id = idToken.toIntOrNull(16) ?: return null
+        val timestamp = tokens[2].toDoubleOrNull() ?: return null
+        // the data bytes are contiguous hex, but some implementations separate them with spaces
+        val dataHex = tokens.drop(3).joinToString("")
+        if (dataHex.length % 2 != 0 || dataHex.length > 2 * CanFrame.MAX_DATA_LENGTH) {
+            return null
+        }
+        val data = try {
+            ByteArray(dataHex.length / 2) { dataHex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+        } catch (e: NumberFormatException) {
+            return null
+        }
+        val extended = idToken.length > 3 || id > CanFrame.MAX_STANDARD_ID
+        if (id > CanFrame.MAX_EXTENDED_ID || id < 0) {
+            return null
+        }
+        return SocketcandMessage.Frame(CanFrame(id = id, data = data, extended = extended), timestamp)
+    }
+
+    fun serializeOpen(busName: String): String =
+        "< open $busName >"
+
+    const val RAWMODE: String = "< rawmode >"
+
+    fun serializeSend(frame: CanFrame): String {
+        val id = frame.id.toString(16).padStart(if (frame.extended) 8 else 3, '0')
+        val data = frame.data.joinToString(" ") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+        return if (frame.data.isEmpty()) {
+            "< send $id ${frame.data.size} >"
+        } else {
+            "< send $id ${frame.data.size} $data >"
+        }
+    }
+}

--- a/src/main/kotlin/library/can/socketcand/SocketcandTransport.kt
+++ b/src/main/kotlin/library/can/socketcand/SocketcandTransport.kt
@@ -1,0 +1,175 @@
+package library.can.socketcand
+
+import io.ktor.network.selector.ActorSelectorManager
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import library.can.CanFrame
+import library.can.CanTransport
+import org.slf4j.LoggerFactory
+import java.io.EOFException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * CAN transport connecting to a socketcand daemon
+ * (https://github.com/linux-can/socketcand) in rawmode over TCP.
+ *
+ * Note: the socketcand protocol has no CAN FD frame support.
+ */
+public class SocketcandTransport(
+    private val host: String,
+    private val port: Int = SocketcandProtocol.DEFAULT_PORT,
+    private val busName: String,
+    private val reconnect: Boolean = true,
+) : CanTransport {
+    private val logger = LoggerFactory.getLogger(SocketcandTransport::class.java)
+
+    override val name: String = "socketcand://$host:$port/$busName"
+
+    override val supportsFd: Boolean = false
+
+    private val _incomingFrames = MutableSharedFlow<CanFrame>(extraBufferCapacity = 1024)
+
+    override val incomingFrames: SharedFlow<CanFrame> = _incomingFrames
+
+    private val selectorManager = ActorSelectorManager(Dispatchers.IO)
+    private val writeMutex = Mutex()
+    private val closed = AtomicBoolean(false)
+
+    @Volatile
+    private var connection: Connection? = null
+
+    private class Connection(
+        val socket: Socket,
+        val readChannel: ByteReadChannel,
+        val writeChannel: ByteWriteChannel,
+    ) {
+        private val tokenizer = SocketcandTokenizer()
+        private val pendingMessages = ArrayDeque<SocketcandMessage>()
+        private val readBuffer = ByteArray(4096)
+
+        suspend fun readMessage(): SocketcandMessage {
+            while (pendingMessages.isEmpty()) {
+                val count = readChannel.readAvailable(readBuffer, 0, readBuffer.size)
+                if (count == -1) {
+                    throw EOFException("Connection closed by socketcand")
+                }
+                tokenizer.feed(String(readBuffer, 0, count, Charsets.US_ASCII))
+                    .forEach { pendingMessages.add(SocketcandProtocol.parse(it)) }
+            }
+            return pendingMessages.removeFirst()
+        }
+    }
+
+    override suspend fun start(scope: CoroutineScope) {
+        connect()
+        scope.launch {
+            readLoop()
+        }
+    }
+
+    override suspend fun sendFrame(frame: CanFrame) {
+        require(!frame.fd) { "socketcand doesn't support CAN FD frames" }
+        val conn = connection ?: throw IllegalStateException("Not connected to $name")
+        writeMutex.withLock {
+            conn.writeChannel.writeStringUtf8(SocketcandProtocol.serializeSend(frame))
+            conn.writeChannel.flush()
+        }
+    }
+
+    override fun close() {
+        closed.set(true)
+        connection?.socket?.close()
+        connection = null
+        selectorManager.close()
+    }
+
+    private suspend fun connect() {
+        logger.debug("Connecting to socketcand at $host:$port (bus $busName)")
+        val socket = aSocket(selectorManager).tcp().connect(host, port)
+        try {
+            val conn = Connection(socket, socket.openReadChannel(), socket.openWriteChannel(autoFlush = true))
+            expect(conn, SocketcandMessage.Hi::class.java, "greeting")
+            conn.writeChannel.writeStringUtf8(SocketcandProtocol.serializeOpen(busName))
+            expect(conn, SocketcandMessage.Ok::class.java, "response to '< open >'")
+            conn.writeChannel.writeStringUtf8(SocketcandProtocol.RAWMODE)
+            expect(conn, SocketcandMessage.Ok::class.java, "response to '< rawmode >'")
+            connection = conn
+            logger.info("Connected to $name")
+        } catch (e: Exception) {
+            socket.close()
+            throw e
+        }
+    }
+
+    private suspend fun expect(conn: Connection, expected: Class<out SocketcandMessage>, context: String) {
+        while (true) {
+            when (val message = conn.readMessage()) {
+                is SocketcandMessage.Error ->
+                    throw IllegalStateException("socketcand at $host:$port returned an error while waiting for $context: ${message.text}")
+                else -> {
+                    if (expected.isInstance(message)) {
+                        return
+                    }
+                    if (message !is SocketcandMessage.Frame) {
+                        throw IllegalStateException("Unexpected message from socketcand at $host:$port while waiting for $context")
+                    }
+                    // ignore frames that were already in flight
+                }
+            }
+        }
+    }
+
+    private suspend fun readLoop() {
+        var reconnectAttempt = 0
+        while (!closed.get() && currentCoroutineContextIsActive()) {
+            val conn = connection
+            if (conn == null) {
+                if (!reconnect) {
+                    break
+                }
+                try {
+                    delay(minOf(30.seconds, 1.seconds * (1 shl minOf(reconnectAttempt, 5))))
+                    reconnectAttempt++
+                    connect()
+                    reconnectAttempt = 0
+                } catch (e: Exception) {
+                    logger.warn("Reconnect to $name failed (attempt $reconnectAttempt): ${e.message}")
+                }
+                continue
+            }
+            try {
+                when (val message = conn.readMessage()) {
+                    is SocketcandMessage.Frame -> _incomingFrames.emit(message.frame)
+                    is SocketcandMessage.Error -> logger.warn("socketcand error on $name: ${message.text}")
+                    else -> logger.debug("Ignoring unexpected socketcand message on $name")
+                }
+            } catch (e: Exception) {
+                if (closed.get()) {
+                    break
+                }
+                logger.warn("Connection to $name lost: ${e.message}")
+                conn.socket.close()
+                connection = null
+                if (!reconnect) {
+                    break
+                }
+            }
+        }
+    }
+
+    private suspend fun currentCoroutineContextIsActive(): Boolean =
+        kotlinx.coroutines.currentCoroutineContext().isActive
+}

--- a/src/test/kotlin/CanBusBindingTest.kt
+++ b/src/test/kotlin/CanBusBindingTest.kt
@@ -1,0 +1,178 @@
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.hasSize
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import library.can.CanFrame
+import library.can.LoopbackCanTransport
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpFraming
+import library.can.isotp.IsoTpOptions
+import library.decodeHex
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+class CanBusBindingTest {
+    private fun testBus(loop: LoopbackCanTransport, busReceiver: CanBusData.() -> Unit = {}): CanBusData =
+        CanBusData("BUS1").apply {
+            transport = loopback(loop)
+            functionalRequestId = 0x7DF
+            ecu("ECU1") {
+                requestId = 0x712
+                responseId = 0x7A2
+                request("22 F1 86") { respond("62 F1 86 01 02 03") }
+                request("3E 00") { ack() }
+                request("10 01") {
+                    pendingFor(50.milliseconds)
+                    respond("50 01")
+                }
+                request("22 10 20") { respond(ByteArray(100) { it.toByte() }) }
+            }
+            busReceiver()
+        }
+
+    private fun withStartedBus(
+        busData: CanBusData,
+        loop: LoopbackCanTransport,
+        block: suspend (tester: IsoTpEndpoint, received: Channel<ByteArray>) -> Unit,
+    ) {
+        val binding = CanBusBinding(busData)
+        binding.start()
+        binding.startNetworking()
+        val scope = CoroutineScope(Dispatchers.IO)
+        try {
+            val received = Channel<ByteArray>(Channel.UNLIMITED)
+            val tester = IsoTpEndpoint(loop, 0x7A2, null, 0x712, IsoTpOptions()) { payload, _ ->
+                received.trySend(payload)
+            }
+            tester.start(scope)
+            runBlocking {
+                withTimeout(5000) {
+                    block(tester, received)
+                }
+            }
+        } finally {
+            scope.cancel()
+            binding.stop()
+        }
+    }
+
+    @Test
+    fun `request and response over the dsl defined bus`() {
+        val loop = LoopbackCanTransport()
+        withStartedBus(testBus(loop), loop) { tester, received ->
+            tester.send("22 F1 86".decodeHex())
+            assertThat(received.receive().toList()).isEqualTo("62 F1 86 01 02 03".decodeHex().toList())
+        }
+    }
+
+    @Test
+    fun `multi frame response is segmented and reassembled`() {
+        val loop = LoopbackCanTransport()
+        withStartedBus(testBus(loop), loop) { tester, received ->
+            tester.send("22 10 20".decodeHex())
+            assertThat(received.receive().toList()).isEqualTo(ByteArray(100) { it.toByte() }.toList())
+        }
+    }
+
+    @Test
+    fun `nrc is sent when no request matches`() {
+        val loop = LoopbackCanTransport()
+        withStartedBus(testBus(loop), loop) { tester, received ->
+            tester.send("11 22".decodeHex())
+            assertThat(received.receive().toList()).isEqualTo(listOf(0x7F.toByte(), 0x11.toByte(), 0x31.toByte()))
+        }
+    }
+
+    @Test
+    fun `pendingFor sends pending nrc before the final response`() {
+        val loop = LoopbackCanTransport()
+        withStartedBus(testBus(loop), loop) { tester, received ->
+            tester.send("10 01".decodeHex())
+            assertThat(received.receive().toList()).isEqualTo(listOf(0x7F.toByte(), 0x10.toByte(), 0x78.toByte()))
+            assertThat(received.receive().toList()).isEqualTo(listOf(0x50.toByte(), 0x01.toByte()))
+        }
+    }
+
+    @Test
+    fun `functional request is answered on the physical response id`() {
+        val loop = LoopbackCanTransport()
+        withStartedBus(testBus(loop), loop) { _, received ->
+            loop.sendFrame(CanFrame(0x7DF, IsoTpFraming.encodeSingleFrame("3E 00".decodeHex(), IsoTpOptions())))
+            assertThat(received.receive().toList()).isEqualTo(listOf(0x7E.toByte(), 0x00.toByte()))
+        }
+    }
+
+    @Test
+    fun `find ecu by name`() {
+        val binding = CanBusBinding(testBus(LoopbackCanTransport()))
+        binding.start()
+        assertThat(binding.findEcuByName("ecu1")).isNotNull()
+        assertThat(binding.findEcuByName("unknown")).isNull()
+    }
+
+    @Test
+    fun `duplicate request ids are rejected`() {
+        val busData = CanBusData("BUS1").apply {
+            transport = loopback()
+            ecu("ECU1") { requestId = 0x712; responseId = 0x7A2 }
+            ecu("ECU2") { requestId = 0x712; responseId = 0x7A3 }
+        }
+        val binding = CanBusBinding(busData)
+        binding.start()
+        assertFailure { binding.startNetworking() }.isInstanceOf(IllegalArgumentException::class)
+    }
+
+    @Test
+    fun `missing addressing is rejected`() {
+        val busData = CanBusData("BUS1").apply {
+            transport = loopback()
+            ecu("ECU1") { requestId = 0x712 }
+        }
+        val binding = CanBusBinding(busData)
+        binding.start()
+        assertFailure { binding.startNetworking() }.isInstanceOf(IllegalArgumentException::class)
+    }
+
+    @Test
+    fun `fd requires a transport with fd support`() {
+        val busData = CanBusData("BUS1").apply {
+            transport = loopback(LoopbackCanTransport(supportsFd = false))
+            fd = true
+            txDlc = 64
+            ecu("ECU1") { requestId = 0x712; responseId = 0x7A2 }
+        }
+        val binding = CanBusBinding(busData)
+        binding.start()
+        assertFailure { binding.startNetworking() }.isInstanceOf(IllegalArgumentException::class)
+    }
+
+    @Test
+    fun `can buses are parsed by the network dsl`() {
+        val networkingData = NetworkingData()
+        networkingData.canBus("BUS1") {
+            transport = loopback()
+            isoTp { blockSize = 4 }
+            ecu("ECU1") {
+                requestId = 0x712
+                responseId = 0x7A2
+                isoTp { stMin = 5 }
+                request("3E 00") { ack() }
+            }
+        }
+        assertThat(networkingData.canBuses).hasSize(1)
+        val bus = networkingData.canBuses.first()
+        assertThat(bus.name).isEqualTo("BUS1")
+        assertThat(bus.ecus).hasSize(1)
+        assertThat(bus.ecus.first().requestId).isEqualTo(0x712)
+        assertThat(bus.ecus.first().requests.size).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/IsoTpEndpointTest.kt
+++ b/src/test/kotlin/IsoTpEndpointTest.kt
@@ -1,0 +1,202 @@
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.*
+import library.can.CanFrame
+import library.can.LoopbackCanTransport
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpException
+import library.can.isotp.IsoTpFraming
+import library.can.isotp.IsoTpOptions
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class IsoTpEndpointTest {
+    private class TestEndpoint(
+        scope: CoroutineScope,
+        transport: LoopbackCanTransport,
+        rxId: Int,
+        functionalRxId: Int?,
+        txId: Int,
+        options: IsoTpOptions = IsoTpOptions(),
+    ) {
+        val received = Channel<Pair<ByteArray, Boolean>>(Channel.UNLIMITED)
+        val endpoint = IsoTpEndpoint(transport, rxId, functionalRxId, txId, options) { payload, functional ->
+            received.trySend(payload to functional)
+        }
+
+        init {
+            endpoint.start(scope)
+        }
+
+        suspend fun send(payload: ByteArray) = endpoint.send(payload)
+    }
+
+    @Test
+    fun `single frame request and response`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, 0x7DF, 0x7A2)
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        tester.send(byteArrayOf(0x3E, 0x00))
+        val (request, functional) = ecu.received.receive()
+        assertThat(request.toList()).isEqualTo(listOf<Byte>(0x3E, 0x00))
+        assertThat(functional).isFalse()
+
+        ecu.send(byteArrayOf(0x7E, 0x00))
+        val (response, _) = tester.received.receive()
+        assertThat(response.toList()).isEqualTo(listOf<Byte>(0x7E, 0x00))
+    }
+
+    @Test
+    fun `multi frame roundtrip with 4095 bytes`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2)
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        val payload = ByteArray(4095) { it.toByte() }
+        tester.send(payload)
+        val (request, _) = ecu.received.receive()
+        assertThat(request.toList()).isEqualTo(payload.toList())
+
+        val response = ByteArray(2048) { (it * 3).toByte() }
+        ecu.send(response)
+        val (received, _) = tester.received.receive()
+        assertThat(received.toList()).isEqualTo(response.toList())
+    }
+
+    @Test
+    fun `multi frame with 32 bit escape length`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2)
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        val payload = ByteArray(100_000) { it.toByte() }
+        tester.send(payload)
+        val (request, _) = ecu.received.receive()
+        assertThat(request.contentEquals(payload)).isTrue()
+    }
+
+    @Test
+    fun `block size and stmin are honored`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2, IsoTpOptions(blockSize = 2, stMin = 10))
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        val payload = ByteArray(100) { it.toByte() }
+        val start = currentTime
+        tester.send(payload)
+        val (request, _) = ecu.received.receive()
+        assertThat(request.toList()).isEqualTo(payload.toList())
+        // 94 bytes after the first frame = 14 consecutive frames, 10 ms separation each
+        assertThat(currentTime - start >= 140).isTrue()
+    }
+
+    @Test
+    fun `fd framing with escape single frame`() = runTest {
+        val bus = LoopbackCanTransport()
+        val options = IsoTpOptions(fd = true, txDlc = 64)
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2, options)
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712, options)
+
+        // fits a single FD frame with escape SF_DL
+        val small = ByteArray(50) { it.toByte() }
+        tester.send(small)
+        assertThat(ecu.received.receive().first.toList()).isEqualTo(small.toList())
+
+        // segmented FD transfer
+        val large = ByteArray(1000) { (it * 7).toByte() }
+        tester.send(large)
+        assertThat(ecu.received.receive().first.toList()).isEqualTo(large.toList())
+    }
+
+    @Test
+    fun `timeout when no flow control arrives`() = runTest {
+        val bus = LoopbackCanTransport()
+        // nobody listens on 0x713, so no flow control will ever arrive
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x713, IsoTpOptions(nBsTimeout = 1.seconds))
+
+        assertFailure {
+            tester.send(ByteArray(100))
+        }.isInstanceOf(IsoTpException::class)
+    }
+
+    @Test
+    fun `receiver overflow aborts transmission`() = runTest {
+        val bus = LoopbackCanTransport()
+        TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2, IsoTpOptions(maxMessageSize = 50))
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        assertFailure {
+            tester.send(ByteArray(100))
+        }.isInstanceOf(IsoTpException::class)
+    }
+
+    @Test
+    fun `functional single frame is dispatched as functional`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, 0x7DF, 0x7A2)
+
+        bus.sendFrame(CanFrame(0x7DF, IsoTpFraming.encodeSingleFrame(byteArrayOf(0x3E, 0x00), IsoTpOptions())))
+        val (request, functional) = ecu.received.receive()
+        assertThat(request.toList()).isEqualTo(listOf<Byte>(0x3E, 0x00))
+        assertThat(functional).isTrue()
+    }
+
+    @Test
+    fun `segmented message on functional id is ignored`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, 0x7DF, 0x7A2)
+
+        val options = IsoTpOptions()
+        bus.sendFrame(CanFrame(0x7DF, IsoTpFraming.encodeFirstFrame(100, ByteArray(6), options)))
+        testScheduler.advanceUntilIdle()
+        assertThat(ecu.received.tryReceive().isSuccess).isFalse()
+
+        // physical requests still work afterwards
+        bus.sendFrame(CanFrame(0x712, IsoTpFraming.encodeSingleFrame(byteArrayOf(0x3E, 0x00), options)))
+        val (request, functional) = ecu.received.receive()
+        assertThat(request.toList()).isEqualTo(listOf<Byte>(0x3E, 0x00))
+        assertThat(functional).isFalse()
+    }
+
+    @Test
+    fun `concurrent transmissions are serialized`() = runTest {
+        val bus = LoopbackCanTransport()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2)
+        val tester = TestEndpoint(backgroundScope, bus, 0x7A2, null, 0x712)
+
+        val first = ByteArray(100) { 0x11 }
+        val second = ByteArray(100) { 0x22 }
+        val sendJobs = listOf(
+            backgroundScope.launch { ecu.send(first) },
+            backgroundScope.launch { ecu.send(second) },
+        )
+        val received = listOf(tester.received.receive().first, tester.received.receive().first)
+        sendJobs.forEach { it.join() }
+        assertThat(received.map { it.toList() }.toSet()).isEqualTo(setOf(first.toList(), second.toList()))
+    }
+
+    @Test
+    fun `sequence number mismatch aborts reception and allows new requests`() = runTest {
+        val bus = LoopbackCanTransport()
+        val options = IsoTpOptions()
+        val ecu = TestEndpoint(backgroundScope, bus, 0x712, null, 0x7A2)
+
+        bus.sendFrame(CanFrame(0x712, IsoTpFraming.encodeFirstFrame(20, ByteArray(6), options)))
+        // wrong sequence number (expected 1)
+        bus.sendFrame(CanFrame(0x712, IsoTpFraming.encodeConsecutiveFrame(3, ByteArray(7), options)))
+        testScheduler.advanceUntilIdle()
+        assertThat(ecu.received.tryReceive().isSuccess).isFalse()
+
+        bus.sendFrame(CanFrame(0x712, IsoTpFraming.encodeSingleFrame(byteArrayOf(0x3E, 0x00), options)))
+        assertThat(ecu.received.receive().first.toList()).isEqualTo(listOf<Byte>(0x3E, 0x00))
+    }
+}

--- a/src/test/kotlin/IsoTpEndpointTest.kt
+++ b/src/test/kotlin/IsoTpEndpointTest.kt
@@ -6,9 +6,11 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.*
 import library.can.CanFrame
+import library.can.CanTransport
 import library.can.LoopbackCanTransport
 import library.can.isotp.IsoTpEndpoint
 import library.can.isotp.IsoTpException
@@ -183,6 +185,38 @@ class IsoTpEndpointTest {
         val received = listOf(tester.received.receive().first, tester.received.receive().first)
         sendJobs.forEach { it.join() }
         assertThat(received.map { it.toList() }.toSet()).isEqualTo(setOf(first.toList(), second.toList()))
+    }
+
+    @Test
+    fun `failing transport send does not kill the frame processing loop`() = runTest {
+        // a transport whose sends fail, like socketcand while disconnected/reconnecting
+        val incoming = MutableSharedFlow<CanFrame>(extraBufferCapacity = 16)
+        val transport = object : CanTransport {
+            override val name = "failing"
+            override val supportsFd = false
+            override val incomingFrames = incoming
+            override suspend fun start(scope: CoroutineScope) {}
+            override suspend fun sendFrame(frame: CanFrame) {
+                throw IllegalStateException("Not connected")
+            }
+
+            override fun close() {}
+        }
+        val received = Channel<ByteArray>(Channel.UNLIMITED)
+        val endpoint = IsoTpEndpoint(transport, 0x712, null, 0x7A2, IsoTpOptions()) { payload, _ ->
+            received.trySend(payload)
+        }
+        endpoint.start(backgroundScope)
+
+        val options = IsoTpOptions()
+        // the first frame provokes a flow control response, whose send fails
+        incoming.emit(CanFrame(0x712, IsoTpFraming.encodeFirstFrame(20, ByteArray(6), options)))
+        testScheduler.advanceUntilIdle()
+        assertThat(received.tryReceive().isSuccess).isFalse()
+
+        // the endpoint must still process frames afterwards
+        incoming.emit(CanFrame(0x712, IsoTpFraming.encodeSingleFrame(byteArrayOf(0x3E, 0x00), options)))
+        assertThat(received.receive().toList()).isEqualTo(listOf<Byte>(0x3E, 0x00))
     }
 
     @Test

--- a/src/test/kotlin/IsoTpEndpointTest.kt
+++ b/src/test/kotlin/IsoTpEndpointTest.kt
@@ -95,8 +95,9 @@ class IsoTpEndpointTest {
         tester.send(payload)
         val (request, _) = ecu.received.receive()
         assertThat(request.toList()).isEqualTo(payload.toList())
-        // 94 bytes after the first frame = 14 consecutive frames, 10 ms separation each
-        assertThat(currentTime - start >= 140).isTrue()
+        // 94 bytes after the first frame = 14 consecutive frames; STmin separates
+        // them, so 13 gaps of 10 ms each (no separation before the first frame)
+        assertThat(currentTime - start >= 130).isTrue()
     }
 
     @Test

--- a/src/test/kotlin/IsoTpFramingTest.kt
+++ b/src/test/kotlin/IsoTpFramingTest.kt
@@ -1,0 +1,151 @@
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import library.can.CanDlc
+import library.can.isotp.IsoTpConsecutiveFrame
+import library.can.isotp.IsoTpFirstFrame
+import library.can.isotp.IsoTpFlowControlFrame
+import library.can.isotp.IsoTpFraming
+import library.can.isotp.IsoTpOptions
+import library.can.isotp.IsoTpSingleFrame
+import org.junit.jupiter.api.Test
+
+class IsoTpFramingTest {
+    private val classic = IsoTpOptions()
+    private val classicNoPadding = IsoTpOptions(paddingByte = null)
+    private val fd64 = IsoTpOptions(fd = true, txDlc = 64)
+
+    @Test
+    fun `single frame roundtrip classic`() {
+        val payload = byteArrayOf(0x22, 0xF1.toByte(), 0x86.toByte())
+        val encoded = IsoTpFraming.encodeSingleFrame(payload, classic)
+        assertThat(encoded.size).isEqualTo(8) // padded
+        assertThat(encoded[0]).isEqualTo(0x03.toByte())
+        assertThat(encoded[4]).isEqualTo(0xCC.toByte())
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpSingleFrame
+        assertThat(decoded.payload.toList()).isEqualTo(payload.toList())
+    }
+
+    @Test
+    fun `single frame without padding keeps exact length`() {
+        val payload = byteArrayOf(0x3E, 0x00)
+        val encoded = IsoTpFraming.encodeSingleFrame(payload, classicNoPadding)
+        assertThat(encoded.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `single frame fd escape roundtrip`() {
+        val payload = ByteArray(40) { it.toByte() }
+        val encoded = IsoTpFraming.encodeSingleFrame(payload, fd64)
+        assertThat(encoded[0]).isEqualTo(0x00.toByte())
+        assertThat(encoded[1]).isEqualTo(40.toByte())
+        assertThat(encoded.size).isEqualTo(CanDlc.nextValidLength(42))
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpSingleFrame
+        assertThat(decoded.payload.toList()).isEqualTo(payload.toList())
+    }
+
+    @Test
+    fun `small payload on fd bus uses classic single frame`() {
+        val payload = ByteArray(5) { it.toByte() }
+        val encoded = IsoTpFraming.encodeSingleFrame(payload, fd64)
+        assertThat(encoded[0]).isEqualTo(0x05.toByte())
+        assertThat(encoded.size).isEqualTo(8)
+    }
+
+    @Test
+    fun `first frame roundtrip 12 bit length`() {
+        val totalLength = 4095
+        val payload = ByteArray(IsoTpFraming.firstFramePayloadSize(totalLength, classic)) { it.toByte() }
+        assertThat(payload.size).isEqualTo(6)
+        val encoded = IsoTpFraming.encodeFirstFrame(totalLength, payload, classic)
+        assertThat(encoded[0]).isEqualTo(0x1F.toByte())
+        assertThat(encoded[1]).isEqualTo(0xFF.toByte())
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpFirstFrame
+        assertThat(decoded.totalLength).isEqualTo(totalLength)
+        assertThat(decoded.payload.toList()).isEqualTo(payload.toList())
+    }
+
+    @Test
+    fun `first frame roundtrip 32 bit escape length`() {
+        val totalLength = 100_000
+        val payload = ByteArray(IsoTpFraming.firstFramePayloadSize(totalLength, classic)) { it.toByte() }
+        assertThat(payload.size).isEqualTo(2)
+        val encoded = IsoTpFraming.encodeFirstFrame(totalLength, payload, classic)
+        assertThat(encoded[0]).isEqualTo(0x10.toByte())
+        assertThat(encoded[1]).isEqualTo(0x00.toByte())
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpFirstFrame
+        assertThat(decoded.totalLength).isEqualTo(totalLength)
+        assertThat(decoded.payload.toList()).isEqualTo(payload.toList())
+    }
+
+    @Test
+    fun `consecutive frame roundtrip`() {
+        val payload = ByteArray(7) { (it + 1).toByte() }
+        val encoded = IsoTpFraming.encodeConsecutiveFrame(5, payload, classic)
+        assertThat(encoded[0]).isEqualTo(0x25.toByte())
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpConsecutiveFrame
+        assertThat(decoded.sequenceNumber).isEqualTo(5)
+        assertThat(decoded.payload.toList()).isEqualTo(payload.toList())
+    }
+
+    @Test
+    fun `short last consecutive frame is padded`() {
+        val payload = ByteArray(2) { it.toByte() }
+        val encoded = IsoTpFraming.encodeConsecutiveFrame(2, payload, classic)
+        assertThat(encoded.size).isEqualTo(8)
+        assertThat(encoded[7]).isEqualTo(0xCC.toByte())
+    }
+
+    @Test
+    fun `flow control roundtrip`() {
+        val encoded = IsoTpFraming.encodeFlowControlFrame(IsoTpFlowControlFrame.CONTINUE_TO_SEND, 8, 20, classic)
+        assertThat(encoded[0]).isEqualTo(0x30.toByte())
+        assertThat(encoded.size).isEqualTo(8)
+        val decoded = IsoTpFraming.decode(encoded) as IsoTpFlowControlFrame
+        assertThat(decoded.status).isEqualTo(IsoTpFlowControlFrame.CONTINUE_TO_SEND)
+        assertThat(decoded.blockSize).isEqualTo(8)
+        assertThat(decoded.stMin).isEqualTo(20)
+    }
+
+    @Test
+    fun `flow control on fd bus stays classic sized`() {
+        val encoded = IsoTpFraming.encodeFlowControlFrame(IsoTpFlowControlFrame.WAIT, 0, 0, fd64)
+        assertThat(encoded.size).isEqualTo(8)
+        assertThat(IsoTpFraming.decode(encoded)).isNotNull().isInstanceOf(IsoTpFlowControlFrame::class)
+    }
+
+    @Test
+    fun `invalid frames decode to null`() {
+        assertThat(IsoTpFraming.decode(ByteArray(0))).isNull()
+        // SF length 0
+        assertThat(IsoTpFraming.decode(byteArrayOf(0x00))).isNull()
+        // SF length exceeds frame
+        assertThat(IsoTpFraming.decode(byteArrayOf(0x07, 0x01))).isNull()
+        // FC with invalid status
+        assertThat(IsoTpFraming.decode(byteArrayOf(0x3F, 0x00, 0x00))).isNull()
+        // unknown PCI
+        assertThat(IsoTpFraming.decode(byteArrayOf(0x40, 0x00))).isNull()
+    }
+
+    @Test
+    fun `stmin conversion`() {
+        assertThat(IsoTpFraming.stMinToMillis(0)).isEqualTo(0L)
+        assertThat(IsoTpFraming.stMinToMillis(0x7F)).isEqualTo(127L)
+        assertThat(IsoTpFraming.stMinToMillis(0xF1)).isEqualTo(1L)
+        assertThat(IsoTpFraming.stMinToMillis(0xF9)).isEqualTo(1L)
+        // reserved values fall back to the maximum
+        assertThat(IsoTpFraming.stMinToMillis(0x80)).isEqualTo(127L)
+        assertThat(IsoTpFraming.stMinToMillis(0xFF)).isEqualTo(127L)
+    }
+
+    @Test
+    fun `dlc helper next valid length`() {
+        assertThat(CanDlc.nextValidLength(0)).isEqualTo(0)
+        assertThat(CanDlc.nextValidLength(8)).isEqualTo(8)
+        assertThat(CanDlc.nextValidLength(9)).isEqualTo(12)
+        assertThat(CanDlc.nextValidLength(33)).isEqualTo(48)
+        assertThat(CanDlc.nextValidLength(64)).isEqualTo(64)
+    }
+}

--- a/src/test/kotlin/MultiTransportTest.kt
+++ b/src/test/kotlin/MultiTransportTest.kt
@@ -1,0 +1,157 @@
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isSameInstanceAs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import library.OutputChannel
+import library.UdsMessage
+import library.can.LoopbackCanTransport
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpOptions
+import library.decodeHex
+import org.junit.jupiter.api.Test
+
+class MultiTransportTest {
+    private fun multiTransportNetwork(loop: LoopbackCanTransport): NetworkingData {
+        val networkingData = NetworkingData()
+        networkingData.multiTransport(
+            networkingData.gateway("GW") {
+                logicalAddress = 0x1010
+            },
+            networkingData.canBus("BUS1") {
+                transport = loopback(loop)
+            },
+        ) {
+            ecu("ECU1") {
+                logicalAddress = 0x1011
+                requestId = 0x712
+                responseId = 0x7A2
+                request("22 01") {
+                    var counter by ecu.storedProperty { 0 }
+                    counter += 1
+                    respond(byteArrayOf(0x62, 0x01, counter.toByte()))
+                }
+            }
+        }
+        return networkingData
+    }
+
+    @Test
+    fun `multiTransport registers the same ecu data on both transports`() {
+        val networkingData = multiTransportNetwork(LoopbackCanTransport())
+        val gatewayEcu = networkingData.doipEntities.first().ecus.single()
+        val canEcu = networkingData.canBuses.first().ecus.single()
+        assertThat(canEcu as EcuData).isSameInstanceAs(gatewayEcu)
+        assertThat(gatewayEcu.logicalAddress).isEqualTo(0x1011.toShort())
+        assertThat(canEcu.requestId).isEqualTo(0x712)
+    }
+
+    @Test
+    fun `dual homed ecu is a single shared instance`() {
+        val networking = SimDoipNetworking(multiTransportNetwork(LoopbackCanTransport()))
+        networking.start()
+
+        val viaDoip = networking.findEcuByName("ECU1")
+        val viaCan = networking.canBusBindings.first().findEcuByName("ECU1")
+        assertThat(viaDoip).isNotNull()
+        assertThat(viaCan).isNotNull()
+        assertThat(viaCan!!).isSameInstanceAs(viaDoip!!)
+    }
+
+    @Test
+    fun `state is shared between can and doip requests`() {
+        val loop = LoopbackCanTransport()
+        val networking = SimDoipNetworking(multiTransportNetwork(loop))
+        networking.start()
+        val binding = networking.canBusBindings.first()
+        binding.startNetworking()
+
+        val scope = CoroutineScope(Dispatchers.IO)
+        try {
+            runBlocking {
+                withTimeout(5000) {
+                    // first request via CAN
+                    val received = Channel<ByteArray>(Channel.UNLIMITED)
+                    val tester = IsoTpEndpoint(loop, 0x7A2, null, 0x712, IsoTpOptions()) { payload, _ ->
+                        received.trySend(payload)
+                    }
+                    tester.start(scope)
+                    tester.send("22 01".decodeHex())
+                    assertThat(received.receive().toList()).isEqualTo("62 01 01".decodeHex().toList())
+
+                    // second request via the DoIP path of the same (shared) instance
+                    val recorded = Channel<ByteArray>(Channel.UNLIMITED)
+                    val recordingOutput = object : OutputChannel {
+                        override suspend fun writeFully(data: ByteArray) {
+                            recorded.trySend(data)
+                        }
+
+                        override suspend fun flush() {}
+                    }
+                    val simEcu = networking.findEcuByName("ECU1")!!
+                    simEcu.onIncomingUdsMessage(
+                        UdsMessage(
+                            sourceAddress = 0x0E00,
+                            targetAddress = 0x1011,
+                            targetAddressType = UdsMessage.PHYSICAL,
+                            targetAddressPhysical = 0x1011,
+                            message = "22 01".decodeHex(),
+                            output = recordingOutput,
+                        )
+                    )
+                    // counter was incremented by the CAN request before - DoIP-framed response ends with 62 01 02
+                    val doipResponse = recorded.receive()
+                    assertThat(doipResponse.takeLast(3)).isEqualTo("62 01 02".decodeHex().toList())
+                }
+            }
+        } finally {
+            scope.cancel()
+            binding.stop()
+        }
+    }
+
+    @Test
+    fun `ecu shared between two can buses is a single instance`() {
+        val networkingData = NetworkingData()
+        networkingData.multiTransport(
+            networkingData.canBus("BUS1") { transport = loopback() },
+            networkingData.canBus("BUS2") { transport = loopback() },
+        ) {
+            ecu("ECU1") {
+                requestId = 0x712
+                responseId = 0x7A2
+            }
+        }
+        val networking = SimDoipNetworking(networkingData)
+        networking.start()
+        val viaBus1 = networking.canBusBindings[0].findEcuByName("ECU1")
+        val viaBus2 = networking.canBusBindings[1].findEcuByName("ECU1")
+        assertThat(viaBus1).isNotNull()
+        assertThat(viaBus2!!).isSameInstanceAs(viaBus1!!)
+    }
+
+    @Test
+    fun `multiTransport rejects invalid target combinations`() {
+        val networkingData = NetworkingData()
+        val gw1 = networkingData.gateway("GW1") { logicalAddress = 0x1010 }
+        val gw2 = networkingData.gateway("GW2") { logicalAddress = 0x2010 }
+        assertFailure {
+            networkingData.multiTransport(gw1, gw2) {}
+        }.isInstanceOf(IllegalArgumentException::class)
+
+        assertFailure {
+            networkingData.multiTransport() {}
+        }.isInstanceOf(IllegalArgumentException::class)
+
+        assertFailure {
+            networkingData.multiTransport(gw1, gw1) {}
+        }.isInstanceOf(IllegalArgumentException::class)
+    }
+}

--- a/src/test/kotlin/SocketCanIntegrationTest.kt
+++ b/src/test/kotlin/SocketCanIntegrationTest.kt
@@ -1,0 +1,72 @@
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpOptions
+import library.can.socketcan.SocketCanTransport
+import library.decodeHex
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Requires a Linux host with a vcan interface (excluded by default, enable with
+ * `gradlew test -PcanIntegrationTests`):
+ * ```
+ * sudo modprobe vcan
+ * sudo ip link add dev vcan0 type vcan
+ * sudo ip link set up vcan0
+ * ```
+ * Can be cross-checked with can-utils, e.g. `candump vcan0` or
+ * `isotpsend -s 712 -d 7a2 vcan0`.
+ */
+@Tag("linux-can")
+@EnabledOnOs(OS.LINUX)
+class SocketCanIntegrationTest {
+    @Test
+    fun `request and response over vcan`() {
+        val busData = CanBusData("VCAN").apply {
+            transport = socketCan("vcan0")
+            ecu("ECU1") {
+                requestId = 0x712
+                responseId = 0x7A2
+                request("22 F1 86") { respond("62 F1 86 01 02 03") }
+                request("22 10 20") { respond(ByteArray(500) { it.toByte() }) }
+            }
+        }
+        val binding = CanBusBinding(busData)
+        binding.start()
+        binding.startNetworking()
+        val scope = CoroutineScope(Dispatchers.IO)
+        val testerTransport = SocketCanTransport("vcan0")
+        try {
+            runBlocking {
+                withTimeout(10_000) {
+                    testerTransport.start(scope)
+                    val received = Channel<ByteArray>(Channel.UNLIMITED)
+                    val tester = IsoTpEndpoint(testerTransport, 0x7A2, null, 0x712, IsoTpOptions()) { payload, _ ->
+                        received.trySend(payload)
+                    }
+                    tester.start(scope)
+
+                    tester.send("22 F1 86".decodeHex())
+                    assertThat(received.receive().toList()).isEqualTo("62 F1 86 01 02 03".decodeHex().toList())
+
+                    // segmented response with flow control
+                    tester.send("22 10 20".decodeHex())
+                    assertThat(received.receive().toList()).isEqualTo(ByteArray(500) { it.toByte() }.toList())
+                }
+            }
+        } finally {
+            testerTransport.close()
+            scope.cancel()
+            binding.stop()
+        }
+    }
+}

--- a/src/test/kotlin/SocketcandTest.kt
+++ b/src/test/kotlin/SocketcandTest.kt
@@ -1,0 +1,173 @@
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import io.ktor.network.selector.ActorSelectorManager
+import io.ktor.network.sockets.InetSocketAddress
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readByte
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import library.can.CanFrame
+import library.can.socketcand.SocketcandMessage
+import library.can.socketcand.SocketcandProtocol
+import library.can.socketcand.SocketcandTokenizer
+import library.can.socketcand.SocketcandTransport
+import org.junit.jupiter.api.Test
+
+class SocketcandTest {
+    @Test
+    fun `tokenizer handles split and coalesced messages`() {
+        val tokenizer = SocketcandTokenizer()
+        assertThat(tokenizer.feed("< hi >< ok >")).isEqualTo(listOf("< hi >", "< ok >"))
+        assertThat(tokenizer.feed("< fra")).isEmpty()
+        assertThat(tokenizer.feed("me 123 23.4242")).isEmpty()
+        assertThat(tokenizer.feed("42 1122 >< o")).isEqualTo(listOf("< frame 123 23.424242 1122 >"))
+        assertThat(tokenizer.feed("k >")).isEqualTo(listOf("< ok >"))
+        // garbage between messages is skipped
+        assertThat(tokenizer.feed("garbage< ok >")).isEqualTo(listOf("< ok >"))
+    }
+
+    @Test
+    fun `parse standard messages`() {
+        assertThat(SocketcandProtocol.parse("< hi >")).isInstanceOf(SocketcandMessage.Hi::class)
+        assertThat(SocketcandProtocol.parse("< ok >")).isInstanceOf(SocketcandMessage.Ok::class)
+        val error = SocketcandProtocol.parse("< error could not open bus >")
+        assertThat(error).isInstanceOf(SocketcandMessage.Error::class)
+        assertThat((error as SocketcandMessage.Error).text).isEqualTo("could not open bus")
+        assertThat(SocketcandProtocol.parse("< echo >")).isInstanceOf(SocketcandMessage.Unknown::class)
+    }
+
+    @Test
+    fun `parse frame with contiguous hex data`() {
+        val message = SocketcandProtocol.parse("< frame 123 23.424242 112233 >")
+        val frame = (message as SocketcandMessage.Frame).frame
+        assertThat(frame.id).isEqualTo(0x123)
+        assertThat(frame.extended).isFalse()
+        assertThat(frame.data.toList()).isEqualTo(listOf(0x11.toByte(), 0x22.toByte(), 0x33.toByte()))
+        assertThat(message.timestamp).isEqualTo(23.424242)
+    }
+
+    @Test
+    fun `parse frame with extended id and empty data`() {
+        val message = SocketcandProtocol.parse("< frame 0000059A 42.0 >")
+        val frame = (message as SocketcandMessage.Frame).frame
+        assertThat(frame.id).isEqualTo(0x59A)
+        assertThat(frame.extended).isTrue()
+        assertThat(frame.data.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `serialize send`() {
+        val frame = CanFrame(0x712, byteArrayOf(0x02, 0x3E, 0x00))
+        assertThat(SocketcandProtocol.serializeSend(frame)).isEqualTo("< send 712 3 02 3e 00 >")
+        val extended = CanFrame(0x59A, ByteArray(0), extended = true)
+        assertThat(SocketcandProtocol.serializeSend(extended)).isEqualTo("< send 0000059a 0 >")
+    }
+
+    @Test
+    fun `handshake and frame exchange against a fake server`() {
+        val selector = ActorSelectorManager(Dispatchers.IO)
+        val scope = CoroutineScope(Dispatchers.IO)
+        runBlocking {
+            val server = aSocket(selector).tcp().bind(InetSocketAddress("127.0.0.1", 0))
+            val port = (server.localAddress as InetSocketAddress).port
+            val receivedSends = Channel<String>(Channel.UNLIMITED)
+
+            val serverJob = scope.launch {
+                val client = server.accept()
+                val readChannel = client.openReadChannel()
+                val writeChannel = client.openWriteChannel(autoFlush = true)
+                writeChannel.writeStringUtf8("< hi >")
+                assertThat(readMessage(readChannel)).isEqualTo("< open can0 >")
+                writeChannel.writeStringUtf8("< ok >")
+                assertThat(readMessage(readChannel)).isEqualTo("< rawmode >")
+                writeChannel.writeStringUtf8("< ok >")
+                // first frame sent by the transport is acknowledged with a frame from the "bus"
+                receivedSends.send(readMessage(readChannel))
+                writeChannel.writeStringUtf8("< frame 7a2 0.000000 62f18601 >")
+            }
+
+            val transport = SocketcandTransport(host = "127.0.0.1", port = port, busName = "can0", reconnect = false)
+            try {
+                withTimeout(5000) {
+                    transport.start(scope)
+                    val incoming = Channel<CanFrame>(Channel.UNLIMITED)
+                    // UNDISPATCHED so the subscription is registered before sendFrame triggers the reply
+                    val collector = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                        transport.incomingFrames.collect { incoming.trySend(it) }
+                    }
+                    transport.sendFrame(CanFrame(0x712, byteArrayOf(0x03, 0x22, 0xF1.toByte(), 0x86.toByte())))
+                    assertThat(receivedSends.receive()).isEqualTo("< send 712 4 03 22 f1 86 >")
+
+                    val frame = incoming.receive()
+                    assertThat(frame.id).isEqualTo(0x7A2)
+                    assertThat(frame.data.toList()).isEqualTo("62F18601".chunked(2).map { it.toInt(16).toByte() })
+                    collector.cancel()
+                    serverJob.join()
+                }
+            } finally {
+                transport.close()
+                server.close()
+                scope.cancel()
+                selector.close()
+            }
+        }
+    }
+
+    @Test
+    fun `error during handshake is reported`() {
+        val selector = ActorSelectorManager(Dispatchers.IO)
+        val scope = CoroutineScope(Dispatchers.IO)
+        runBlocking {
+            val server = aSocket(selector).tcp().bind(InetSocketAddress("127.0.0.1", 0))
+            val port = (server.localAddress as InetSocketAddress).port
+            val serverJob = scope.launch {
+                val client = server.accept()
+                val readChannel = client.openReadChannel()
+                val writeChannel = client.openWriteChannel(autoFlush = true)
+                writeChannel.writeStringUtf8("< hi >")
+                readMessage(readChannel)
+                writeChannel.writeStringUtf8("< error no such bus >")
+            }
+
+            val transport = SocketcandTransport(host = "127.0.0.1", port = port, busName = "nosuchbus", reconnect = false)
+            try {
+                withTimeout(5000) {
+                    val exception = runCatching { transport.start(scope) }.exceptionOrNull()
+                    assertThat(exception is IllegalStateException).isTrue()
+                    assertThat(exception!!.message!!.contains("no such bus")).isTrue()
+                    serverJob.join()
+                }
+            } finally {
+                transport.close()
+                server.close()
+                scope.cancel()
+                selector.close()
+            }
+        }
+    }
+
+    private suspend fun readMessage(channel: ByteReadChannel): String {
+        val sb = StringBuilder()
+        while (true) {
+            val c = channel.readByte().toInt().toChar()
+            sb.append(c)
+            if (c == '>') {
+                return sb.toString().trim()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add CAN bus binding and DSL (CanBusBinding, SimCanDsl, SimMultiTransportDsl)
- Add ISO-TP framing and endpoint implementation for CAN UDS messaging
- Add SocketCAN and socketcand transport backends
- Extend SimNetworking and SimDoipEntity to support multiple transports
- Add comprehensive tests for CAN bus, ISO-TP, socketcand, and multi-transport
- Update build.gradle.kts and settings.gradle.kts for new modules/dependencies
- Update README.md with CAN bus usage documentation