### PR TITLE
fix(doip): don't let closed-channel writes escape the coroutine

### DIFF
--- a/src/main/kotlin/NetworkHandler.kt
+++ b/src/main/kotlin/NetworkHandler.kt
@@ -1,5 +1,6 @@
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
+import io.ktor.utils.io.ClosedWriteChannelException
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
@@ -422,6 +423,15 @@ public open class TcpNetworkBinding(
                                     handler.connectionClosed(e)
                                     socket.runCatching { this.close() }
                                 }
+                            } catch (e: ClosedWriteChannelException) {
+                                // As of ktor 3.5, writing to a channel whose peer already
+                                // disconnected throws eagerly. Not an error: the connection
+                                // is simply gone, so clean up quietly.
+                                logger.debugIf { "Write channel closed by remote $remoteAddress" }
+                                withContext(Dispatchers.IO) {
+                                    handler.connectionClosed(e)
+                                    socket.runCatching { this.close() }
+                                }
                             } catch (e: SocketException) {
                                 logger.error("Socket error: ${e.message} -> closing socket")
                                 withContext(Dispatchers.IO) {
@@ -436,7 +446,10 @@ public open class TcpNetworkBinding(
                                     )
                                     val response =
                                         DoipTcpHeaderNegAck(DoipTcpDiagMessageNegAck.NACK_CODE_TRANSPORT_PROTOCOL_ERROR).asByteArray
-                                    output.writeFully(response)
+                                    // Best effort: the peer may have disconnected in the
+                                    // meantime, and as of ktor 3.5 writing to a closed
+                                    // channel throws; the socket is torn down either way.
+                                    output.runCatching { writeFully(response) }
                                     withContext(Dispatchers.IO) {
                                         handler.connectionClosed(e)
                                         socket.runCatching { this.close() }
@@ -444,14 +457,23 @@ public open class TcpNetworkBinding(
                                 }
                             } catch (e: DoipEntityHardResetException) {
                                 logger.warn("Simulating Hard Reset on ${e.ecu.name} for ${e.duration.inWholeMilliseconds} ms")
-                                output.flush()
+                                output.runCatching { flush() }
 
                                 networkBinding.hardResetEcuFor(
                                     this@ActiveConnection,
                                     e.ecu.config.logicalAddress,
                                     e.duration
                                 )
-                            } catch (e: Exception) {
+                            } catch (e: CancellationException) {
+                                // Never swallow cancellation: this message coroutine is a
+                                // child of the server scope, so cooperative cancellation
+                                // must be allowed to propagate.
+                                throw e
+                            } catch (e: Throwable) {
+                                // Last-resort guard: anything escaping this coroutine
+                                // cancels the whole server scope and takes the DoIP
+                                // entity permanently offline, so handle every failure
+                                // here (Throwable, not Exception).
                                 if (!socket.isClosed) {
                                     logger.error(
                                         "Unknown error parsing/handling message, sending negative acknowledgment",
@@ -459,9 +481,10 @@ public open class TcpNetworkBinding(
                                     )
                                     val response =
                                         DoipTcpHeaderNegAck(DoipTcpDiagMessageNegAck.NACK_CODE_TRANSPORT_PROTOCOL_ERROR).asByteArray
-                                    output.writeFully(response)
+                                    // Best effort, see the HeaderNegAckException catch above.
+                                    output.runCatching { writeFully(response) }
                                     withContext(Dispatchers.IO) {
-                                        handler.connectionClosed(e)
+                                        handler.connectionClosed(e as? Exception ?: RuntimeException(e))
                                         socket.runCatching { this.close() }
                                     }
                                 }


### PR DESCRIPTION
As of ktor 3.5, writing to a channel whose peer has already disconnected throws ClosedWriteChannelException eagerly (from
ByteChannel.getWriteBuffer). In TcpNetworkBinding.handleTcpSocket each DoIP message is handled in a coroutine whose parent chain ends at the shared TCP server scope, and three writes in its error paths can hit such a channel:

- the negative-acknowledgment write in the HeaderNegAckException catch
- the negative-acknowledgment write in the generic Exception catch
- output.flush() in the DoipEntityHardResetException catch

For the first two, the throw originates inside the catch block itself, so nothing handles it; it propagates out of the per-message coroutine and cancels the whole server scope ("Exception in thread TCP"). The DoIP entity then stops accepting TCP connections until the process is restarted: every subsequent routing activation times out. The !socket.isClosed guards do not prevent this, because during a disconnect/reconnect the write channel is already closed while isClosed still reads false.

Fix:

- catch ClosedWriteChannelException explicitly and clean up the connection quietly: the peer is gone, this is not an error, and sending a negative acknowledgment is pointless
- make the negative-acknowledgment writes and the hard-reset flush() best-effort (runCatching): the socket is being torn down either way
- turn the generic catch (e: Exception) into a last-resort catch (e: Throwable) that rethrows CancellationException first, so no failure can escape the per-message coroutine into the server scope